### PR TITLE
Increase backoff exponential factor

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.2.6.3",
+    version="1.2.6.4",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -24,6 +24,9 @@ DATE_WINDOW_SIZE = 1
 # We will retry a 500 error a maximum of 5 times before giving up
 MAX_RETRIES = 5
 
+# Factor to multiply the exponentiation by.
+FACTOR = 3
+
 def is_not_status_code_fn(status_code):
     def gen_fn(exc):
         if getattr(exc, 'code', None) and exc.code not in status_code:
@@ -65,7 +68,8 @@ def shopify_error_handling(fnc):
                           ),
                           giveup=is_not_status_code_fn(range(500, 599)),
                           on_backoff=retry_handler,
-                          max_tries=MAX_RETRIES)
+                          max_tries=MAX_RETRIES,
+                          factor=FACTOR)
     @backoff.on_exception(retry_after_wait_gen,
                           pyactiveresource.connection.ClientError,
                           giveup=is_not_status_code_fn([429]),


### PR DESCRIPTION
## Context

The current shopify api calls are not backing off enough on server errors:

```bash
INFO Backing off get_refunds(...) for 0.3s (pyactiveresource.connection.ServerError: Service Temporarily Unavailable)
INFO Received 500 or retryable error -- Retry 1/5

INFO Backing off get_refunds(...) for 1.5s (pyactiveresource.connection.ServerError: Service Temporarily Unavailable)
INFO Received 500 or retryable error -- Retry 2/5

INFO Backing off get_refunds(...) for 2.3s (pyactiveresource.connection.ServerError: Service Temporarily Unavailable)
INFO Received 500 or retryable error -- Retry 3/5

INFO Backing off get_refunds(...) for 2.3s (pyactiveresource.connection.ServerError: Service Temporarily Unavailable)
INFO Received 500 or retryable error -- Retry 4/5

ERROR Giving up get_refunds(...) after 5 tries (pyactiveresource.connection.ServerError: Service Temporarily Unavailable)
CRITICAL Service Temporarily Unavailable
```

[Asana Task](https://app.asana.com/0/372558981205281/1200966338042656/f)
[Cloudwatch logs](https://ap-southeast-2.console.aws.amazon.com/cloudwatch/home?region=ap-southeast-2#logsV2:log-groups/log-group/$252Fsyslog$252Fau-identity-integrations$252Fshopify/log-events/shopify$252Fau-identity-integrations$252Ff0fbfc6b1e73459f9e4b1d5df58ad6e7)

## Solution

Increase the `Exponential factor` from 1 to 3.

[Backoff method](https://github.com/litl/backoff/blob/c2f4e1826b1996348177215f4c009c055777603f/backoff/_wait_gen.py#L7)
[On exception decorator](https://github.com/litl/backoff/blob/b9762195912cc83d59ca207742ebf6cecfbbf68d/backoff/_decorator.py#L123)