### PR TITLE
Bump max retries to 9 attempts on 500 errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.2.6.4",
+    version="1.2.6.5",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -21,8 +21,8 @@ RESULTS_PER_PAGE = 175
 # large for a customer)
 DATE_WINDOW_SIZE = 1
 
-# We will retry a 500 error a maximum of 5 times before giving up
-MAX_RETRIES = 5
+# We will retry a 500 error a maximum of 9 times before giving up
+MAX_RETRIES = 9
 
 # Factor to multiply the exponentiation by.
 FACTOR = 3


### PR DESCRIPTION
## Context

We are experience some 500 errors for historical pulls where we are still not backing off enough.

## Solution

Change `MAX_RETRIES` from 5 to 9.

Main method retry strategy: `factor * base ** n` - `3 * 2 ** n`
Retry 1: 3s
Retry 2: 6s
Retry 3: 12s
Retry 4: 24s
Retry 5: 48s
Retry 6: 96s ~1.6min
Retry 7: 192s ~3.2min
Retry 8: 384s ~6.4min
Retry 9: 768s ~12.8min

[Linked PR](https://github.com/lexerdev/tap-shopify/pull/6)

[Backoff method](https://github.com/litl/backoff/blob/c2f4e1826b1996348177215f4c009c055777603f/backoff/_wait_gen.py#L7)
[Cloudwatch logs](https://buildkite.com/lexer/integrations-au/builds/25043)