### PR TITLE
add retry decorator to product requests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.2.6.5",
+    version="1.2.6.6",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/tap_shopify/streams/collection_products.py
+++ b/tap_shopify/streams/collection_products.py
@@ -12,6 +12,7 @@ class CollectionProducts(Stream):
     replication_object = shopify.CustomCollection
     replication_key = 'updated_at'
 
+    @shopify_error_handling
     def get_objects(self):
         
         while True:

--- a/tap_shopify/streams/custom_collections_products.py
+++ b/tap_shopify/streams/custom_collections_products.py
@@ -12,6 +12,7 @@ class CustomCollectionsProducts(Stream):
     replication_object = shopify.CustomCollection
     replication_key = 'updated_at'
 
+    @shopify_error_handling
     def get_objects(self):
         'Paginate the return and add collection_id to returned product objects'
         page = self.replication_object.find()

--- a/tap_shopify/streams/smart_collections_products.py
+++ b/tap_shopify/streams/smart_collections_products.py
@@ -11,7 +11,7 @@ class SmartCollectionsProducts(Stream):
     replication_object = shopify.SmartCollection
     replication_key = 'updated_at'
 
-
+    @shopify_error_handling
     def get_objects(self):
         'Paginate the return and add collection_id to returned product objects'
         page = self.replication_object.find()


### PR DESCRIPTION
## Context:
* When we added these classes to pull product collections data we were missing a decorator for request retrying


## ASANA:
* https://app.asana.com/0/1200015380021498/1201255718450279/f