### PR TITLE
api version 2021-04 -> 2021-07

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.2.6.6",
+    version="1.2.6.7",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -20,7 +20,7 @@ LOGGER = singer.get_logger()
 def initialize_shopify_client():
     api_key = Context.config['api_key']
     shop = Context.config['shop']
-    version = '2021-04'
+    version = '2021-07'
     session = shopify.Session(shop, version, api_key)
     shopify.ShopifyResource.activate_session(session)
 


### PR DESCRIPTION
## Context:
* Shopify have been emailing us because we are making requests to API version 2021-04.
* Bumped to 2021-07 same as our v1 integration.