### PR TITLE
Adjust 429 handling (bugfix)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
     steps:
       - checkout
       - run:
@@ -32,13 +32,7 @@ jobs:
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            run-test --tap=tap-shopify \
-                     --target=target-stitch \
-                     --orchestrator=stitch-orchestrator \
-                     --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$SANDBOX_PASSWORD \
-                     --client-id=50 \
-                     tests
+            run-test --tap=tap-shopify tests
       - slack/notify-on-failure:
           only_for_branches: master
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       - run:
           name: 'Integration Tests'
           command: |
-            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             run-test --tap=tap-shopify \
@@ -51,7 +51,7 @@ workflows:
   build_daily:
     triggers:
       - schedule:
-          cron: "0 14 * * *"
+          cron: "0 6 * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,18 @@ jobs:
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             stitch-validate-json tap_shopify/schemas/*.json
       - run:
+          name: 'Unit Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-shopify/bin/activate
+            pip install nose coverage
+            nosetests --with-coverage --cover-erase --cover-package=tap_shopify --cover-html-dir=htmlcov tests/unittests
+            coverage html
+      - store_test_results:
+          path: test_output/report.xml
+      - store_artifacts:
+          path: htmlcov
+      - add_ssh_keys
+      - run:
           name: 'Integration Tests'
           command: |
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           name: 'JSON Validator'
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            stitch-validate-json /usr/local/share/virtualenvs/tap-shopify/lib/python3.5/site-packages/tap_shopify/schemas/*.json
+            stitch-validate-json tap_shopify/schemas/*.json
       - add_ssh_keys
       - run:
           name: 'Integration Tests'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,11 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-shopify/bin/activate
             make test
+      - run:
+          name: 'JSON Validator'
+          command: |
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            stitch-validate-json /usr/local/share/virtualenvs/tap-shopify/lib/python3.5/site-packages/tap_shopify/schemas/*.json
       - add_ssh_keys
       - run:
           name: 'Integration Tests'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,6 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             stitch-validate-json tap_shopify/schemas/*.json
-      - add_ssh_keys
       - run:
           name: 'Integration Tests'
           command: |
@@ -38,18 +37,18 @@ jobs:
 
 workflows:
   version: 2
-  commit:
+  commit: &commit_jobs
     jobs:
       - build:
-          context: circleci-user
+          context:
+            - circleci-user
+            - tier-1-tap-user
   build_daily:
+    <<: *commit_jobs
     triggers:
       - schedule:
-          cron: "0 6 * * *"
+          cron: "0 1 * * *"
           filters:
             branches:
               only:
                 - master
-    jobs:
-      - build:
-          context: circleci-user

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.2
+  * Add `python_requires` to `setup.py` [#101](https://github.com/singer-io/tap-shopify/pull/101)
+    * We've tested the tap on `python 3.5.2` and `python 3.8.0`
+
 ## 1.3.1
   * Canonicalize `Timestamp` to `timestamp` on `Transactions.receipt` [#98](https://github.com/singer-io/tap-shopify/pull/98)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.5
+  * Add `status` field to `Products` stream [#108](https://github.com/singer-io/tap-shopify/pull/108)
+
 ## 1.3.4
   * Correct abandoned_checkouts schema to correctly reflect some properties as arrays [#44](https://github.com/singer-io/tap-shopify/pull/44)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 1.5.1
+  * Request Timeout Implementation [#129](https://github.com/singer-io/tap-shopify/pull/129)
 ## 1.5.0
   * Adds `events` stream [#127](https://github.com/singer-io/tap-shopify/pull/127)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.4
+  * Correct abandoned_checkouts schema to correctly reflect some properties as arrays [#44](https://github.com/singer-io/tap-shopify/pull/44)
+
 ## 1.3.3.
   * Add `build` to the list of fields we canonicalize for the Transactions stream [#103](https://github.com/singer-io/tap-shopify/pull/103)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.1
+  * Canonicalize `Timestamp` to `timestamp` on `Transactions.receipt` [#98](https://github.com/singer-io/tap-shopify/pull/98)
+
 ## 1.3.0
   This version ships both [#96][PR#96] and [#97][PR#97].
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.6
+  * Fixes a bug in the canonicalize function for a 'receipt' key existing with a null value [#119](https://github.com/singer-io/tap-shopify/pull/119)
+
 ## 1.3.5
   * Add `status` field to `Products` stream [#108](https://github.com/singer-io/tap-shopify/pull/108)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.8
+  * Modified schema so that all fields using `multipleOf` are now using `singer.decimal` [#88](https://github.com/singer-io/tap-shopify/pull/88)
+
 ## 1.2.7
   * Change how exceptions are logged to make the error messages more consistent [#84](https://github.com/singer-io/tap-shopify/pull/84)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.10
+  * Add `null, object` to customer schema definition [#94](https://github.com/singer-io/tap-shopify/pull/94)
+
 ## 1.2.9
   * Bumps `singer-python` from `5.11.0` to `5.12.1` [#91](https://github.com/singer-io/tap-shopify/pull/91)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.5.0
+  * Adds `events` stream [#127](https://github.com/singer-io/tap-shopify/pull/127)
+
 ## 1.4.0
   * Add shop info in record [#115](https://github.com/singer-io/tap-shopify/pull/115)
   * Add inventory item data [#118] (https://github.com/singer-io/tap-shopify/pull/118)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 1.3.0
+  This version ships both [#96][PR#96] and [#97][PR#97].
+
+  From [#97][PR#97]:
+  * removes the "untestable streams" list from all tests.
+  * makes the test match the tap and expect the default page size to be 175, not 250
+  * adds bookmarking to order_refunds
+  * adds bookmarking to transactions
+  * adds shopify error handling to transactions
+    * The tests would fail with unhandled 429s
+  * adds pagination to transactions
+
+  From [#96][PR#96]:
+  * Update the API version from `2020-10` to `2021-04`
+
+  [PR#97]: https://github.com/singer-io/tap-shopify/pull/97/
+  [PR#96]: https://github.com/singer-io/tap-shopify/pull/96
+
 ## 1.2.10
   * Add `null, object` to customer schema definition [#94](https://github.com/singer-io/tap-shopify/pull/94)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.4.0
+  * Add shop info in record [#115](https://github.com/singer-io/tap-shopify/pull/115)
+  * Add inventory item data [#118] (https://github.com/singer-io/tap-shopify/pull/118)
+  * Add Locations stream and TDL-13614: Add Inventory Levels stream [#114] (https://github.com/singer-io/tap-shopify/pull/114)
+  * Added best practices [#116] (https://github.com/singer-io/tap-shopify/pull/116)
+  * Discover mode should check token [#120] (https://github.com/singer-io/tap-shopify/pull/120)
 ## 1.3.6
   * Fixes a bug in the canonicalize function for a 'receipt' key existing with a null value [#119](https://github.com/singer-io/tap-shopify/pull/119)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
+## 1.2.7
+  * Change how exceptions are logged to make the error messages more consistent [#84](https://github.com/singer-io/tap-shopify/pull/84)
+
 ## 1.2.6
-  * Accepts any string for `accepts_marketing_updated_at` field on the `customers` stream [#69] (https://github.com/singer-io/tap-shopify/pull/69)
+  * Accepts any string for `accepts_marketing_updated_at` field on the `customers` stream [#69](https://github.com/singer-io/tap-shopify/pull/69)
 
 ## 1.2.5
   * Bumps `singer-python` from `5.4.1` to `5.9.1` [#67](https://github.com/singer-io/tap-shopify/pull/67)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.9
+  * Bumps `singer-python` from `5.11.0` to `5.12.1` [#91](https://github.com/singer-io/tap-shopify/pull/91)
+
 ## 1.2.8
   * Modified schema so that all fields using `multipleOf` are now using `singer.decimal` [#88](https://github.com/singer-io/tap-shopify/pull/88)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.3.
+  * Add `build` to the list of fields we canonicalize for the Transactions stream [#103](https://github.com/singer-io/tap-shopify/pull/103)
+
 ## 1.3.2
   * Add `python_requires` to `setup.py` [#101](https://github.com/singer-io/tap-shopify/pull/101)
     * We've tested the tap on `python 3.5.2` and `python 3.8.0`

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := test
 
 test:
-	pylint tap_shopify -d missing-docstring
+	pylint tap_shopify -d missing-docstring,too-many-branches
 	nosetests tests/unittests

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This tap:
   - [Orders](https://help.shopify.com/en/api/reference/orders)
   - [Products](https://help.shopify.com/en/api/reference/products)
   - [Transactions](https://help.shopify.com/en/api/reference/orders/transaction)
+  - [Inventory Item](https://help.shopify.com/en/api/reference/inventory/inventoryitem)
 - Outputs the schema for each resource
 - Incrementally pulls data based on the input state
 - When Metafields are selected, this tap will sync the Shopify store's top-level Metafields and any additional Metafields for selected tables that also have them (ie: Orders, Products, Customers)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ This tap:
     {
         "start_date": "2010-01-01",
         "api_key": "<Shopify API Key>",
-        "shop": "test_shop"
+        "shop": "test_shop",
+        "request_timeout": 300
     }
     ```
 
@@ -47,6 +48,8 @@ This tap:
    The `api_key` is the API key for your Shopify shop generated via an OAuth flow.
 
    The `shop` is your Shopify shop which will be the value `test_shop` in the string `https://test_shop.myshopify.com`
+
+    The `request_timeout` is the timeout for the requests. Default: 300 seconds
 
 4. Run the Tap in Discovery Mode
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ This tap:
   - [Orders](https://help.shopify.com/en/api/reference/orders)
   - [Products](https://help.shopify.com/en/api/reference/products)
   - [Transactions](https://help.shopify.com/en/api/reference/orders/transaction)
+  - [Locations](https://help.shopify.com/en/api/reference/inventory/location)
+  - [Inventory Levels](https://help.shopify.com/en/api/reference/inventory/inventorylevel)
   - [Inventory Item](https://help.shopify.com/en/api/reference/inventory/inventoryitem)
 - Outputs the schema for each resource
 - Incrementally pulls data based on the input state

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.2.6.7",
+    version="1.2.6.8",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     classifiers=["Programming Language :: Python :: 3 :: Only"],
     py_modules=["tap_shopify"],
     install_requires=[
-        "ShopifyAPI==8.0.1",
+        "ShopifyAPI==8.4.1",
         "singer-python==5.12.1",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.3.4",
+    version="1.3.5",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.2.10",
+    version="1.3.0",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.2.8",
+    version="1.2.9",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",
@@ -11,7 +11,7 @@ setup(
     py_modules=["tap_shopify"],
     install_requires=[
         "ShopifyAPI==8.0.1",
-        "singer-python==5.11.0",
+        "singer-python==5.12.1",
     ],
     extras_require={
         'dev': [

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.3.0",
+    version="1.3.1",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.2.6",
+    version="1.2.7",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.4.0",
+    version="1.5.0",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.2.9",
+    version="1.2.10",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.3.1",
+    version="1.3.2",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.5.0",
+    version="1.5.1",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     py_modules=["tap_shopify"],
     install_requires=[
         "ShopifyAPI==8.0.1",
-        "singer-python==5.9.1",
+        "singer-python==5.11.0",
     ],
     extras_require={
         'dev': [

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.2.7",
+    version="1.2.8",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.3.2",
+    version="1.3.3",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.3.5",
+    version="1.3.6",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     ],
     extras_require={
         'dev': [
-            'pylint',
+            'pylint==2.7.4',
             'ipdb',
             'requests==2.20.0',
             'nose',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     python_requires='>=3.5.2',
     py_modules=["tap_shopify"],
     install_requires=[
-        "ShopifyAPI==8.4.1",
+        "ShopifyAPI",
         "singer-python==5.12.1",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.3.6",
+    version="1.4.0",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.3.3",
+    version="1.3.4",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",
     classifiers=["Programming Language :: Python :: 3 :: Only"],
+    python_requires='>=3.5.2',
     py_modules=["tap_shopify"],
     install_requires=[
         "ShopifyAPI==8.4.1",

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -21,7 +21,7 @@ LOGGER = singer.get_logger()
 def initialize_shopify_client():
     api_key = Context.config['api_key']
     shop = Context.config['shop']
-    version = '2020-07'
+    version = '2021-04'
     session = shopify.Session(shop, version, api_key)
     shopify.ShopifyResource.activate_session(session)
 

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -14,18 +14,24 @@ from singer import metadata
 from singer import Transformer
 from tap_shopify.context import Context
 from tap_shopify.exceptions import ShopifyError
+from tap_shopify.streams.base import shopify_error_handling, get_request_timeout
 import tap_shopify.streams # Load stream objects into Context
 
 REQUIRED_CONFIG_KEYS = ["shop", "api_key"]
 LOGGER = singer.get_logger()
 SDC_KEYS = {'id': 'integer', 'name': 'string', 'myshopify_domain': 'string'}
 
+@shopify_error_handling
 def initialize_shopify_client():
     api_key = Context.config['api_key']
     shop = Context.config['shop']
     version = '2021-04'
     session = shopify.Session(shop, version, api_key)
     shopify.ShopifyResource.activate_session(session)
+
+    # set request timeout
+    shopify.Shop.set_timeout(get_request_timeout())
+
     # Shop.current() makes a call for shop details with provided shop and api_key
     return shopify.Shop.current().attributes
 

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -12,6 +12,7 @@ from singer import utils
 from singer import metadata
 from singer import Transformer
 from tap_shopify.context import Context
+from tap_shopify.exceptions import ShopifyError
 import tap_shopify.streams # Load stream objects into Context
 
 REQUIRED_CONFIG_KEYS = ["shop", "api_key"]
@@ -140,15 +141,32 @@ def sync():
         Context.state['bookmarks']['currently_sync_stream'] = stream_id
 
         with Transformer() as transformer:
-            for rec in stream.sync():
-                extraction_time = singer.utils.now()
-                record_schema = catalog_entry['schema']
-                record_metadata = metadata.to_map(catalog_entry['metadata'])
-                rec = transformer.transform(rec, record_schema, record_metadata)
-                singer.write_record(stream_id,
-                                    rec,
-                                    time_extracted=extraction_time)
-                Context.counts[stream_id] += 1
+            try:
+                for rec in stream.sync():
+                    extraction_time = singer.utils.now()
+                    record_schema = catalog_entry['schema']
+                    record_metadata = metadata.to_map(catalog_entry['metadata'])
+                    rec = transformer.transform(rec, record_schema, record_metadata)
+                    singer.write_record(stream_id,
+                                        rec,
+                                        time_extracted=extraction_time)
+                    Context.counts[stream_id] += 1
+            except pyactiveresource.connection.ResourceNotFound as exc:
+                raise ShopifyError(exc, 'Ensure shop is entered correctly') from exc
+            except pyactiveresource.connection.UnauthorizedAccess as exc:
+                raise ShopifyError(exc, 'Invalid access token - Re-authorize the connection') \
+                    from exc
+            except pyactiveresource.connection.ConnectionError as exc:
+                msg = ''
+                try:
+                    body_json = exc.response.body.decode()
+                    body = json.loads(body_json)
+                    msg = body.get('errors')
+                finally:
+                    raise ShopifyError(exc, msg) from exc
+            except Exception as exc:
+                raise ShopifyError(exc) from exc
+
 
         Context.state['bookmarks'].pop('currently_sync_stream')
         singer.write_state(Context.state)
@@ -160,7 +178,6 @@ def sync():
 
 @utils.handle_top_exception(LOGGER)
 def main():
-
     # Parse command line arguments
     args = utils.parse_args(REQUIRED_CONFIG_KEYS)
 

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -24,6 +24,8 @@ def initialize_shopify_client():
     version = '2021-04'
     session = shopify.Session(shop, version, api_key)
     shopify.ShopifyResource.activate_session(session)
+    # Shop.current() makes a call for shop details with provided shop and api_key
+    return shopify.Shop.current().attributes
 
 def get_abs_path(path):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
@@ -70,6 +72,8 @@ def load_schema_references():
     return refs
 
 def discover():
+    initialize_shopify_client() # Checking token in discover mode
+
     raw_schemas = load_schemas()
     streams = []
 
@@ -141,32 +145,15 @@ def sync():
         Context.state['bookmarks']['currently_sync_stream'] = stream_id
 
         with Transformer() as transformer:
-            try:
-                for rec in stream.sync():
-                    extraction_time = singer.utils.now()
-                    record_schema = catalog_entry['schema']
-                    record_metadata = metadata.to_map(catalog_entry['metadata'])
-                    rec = transformer.transform(rec, record_schema, record_metadata)
-                    singer.write_record(stream_id,
-                                        rec,
-                                        time_extracted=extraction_time)
-                    Context.counts[stream_id] += 1
-            except pyactiveresource.connection.ResourceNotFound as exc:
-                raise ShopifyError(exc, 'Ensure shop is entered correctly') from exc
-            except pyactiveresource.connection.UnauthorizedAccess as exc:
-                raise ShopifyError(exc, 'Invalid access token - Re-authorize the connection') \
-                    from exc
-            except pyactiveresource.connection.ConnectionError as exc:
-                msg = ''
-                try:
-                    body_json = exc.response.body.decode()
-                    body = json.loads(body_json)
-                    msg = body.get('errors')
-                finally:
-                    raise ShopifyError(exc, msg) from exc
-            except Exception as exc:
-                raise ShopifyError(exc) from exc
-
+            for rec in stream.sync():
+                extraction_time = singer.utils.now()
+                record_schema = catalog_entry['schema']
+                record_metadata = metadata.to_map(catalog_entry['metadata'])
+                rec = transformer.transform(rec, record_schema, record_metadata)
+                singer.write_record(stream_id,
+                                    rec,
+                                    time_extracted=extraction_time)
+                Context.counts[stream_id] += 1
 
         Context.state['bookmarks'].pop('currently_sync_stream')
         singer.write_state(Context.state)
@@ -178,24 +165,41 @@ def sync():
 
 @utils.handle_top_exception(LOGGER)
 def main():
-    # Parse command line arguments
-    args = utils.parse_args(REQUIRED_CONFIG_KEYS)
-
-    # If discover flag was passed, run discovery mode and dump output to stdout
-    if args.discover:
-        catalog = discover()
-        print(json.dumps(catalog, indent=2))
-    # Otherwise run in sync mode
-    else:
-        Context.tap_start = utils.now()
-        if args.catalog:
-            Context.catalog = args.catalog.to_dict()
-        else:
-            Context.catalog = discover()
+    try:
+        # Parse command line arguments
+        args = utils.parse_args(REQUIRED_CONFIG_KEYS)
 
         Context.config = args.config
         Context.state = args.state
-        sync()
+
+        # If discover flag was passed, run discovery mode and dump output to stdout
+        if args.discover:
+            catalog = discover()
+            print(json.dumps(catalog, indent=2))
+        # Otherwise run in sync mode
+        else:
+            Context.tap_start = utils.now()
+            if args.catalog:
+                Context.catalog = args.catalog.to_dict()
+            else:
+                Context.catalog = discover()
+
+            sync()
+    except pyactiveresource.connection.ResourceNotFound as exc:
+        raise ShopifyError(exc, 'Ensure shop is entered correctly') from exc
+    except pyactiveresource.connection.UnauthorizedAccess as exc:
+        raise ShopifyError(exc, 'Invalid access token - Re-authorize the connection') \
+            from exc
+    except pyactiveresource.connection.ConnectionError as exc:
+        msg = ''
+        try:
+            body_json = exc.response.body.decode()
+            body = json.loads(body_json)
+            msg = body.get('errors')
+        finally:
+            raise ShopifyError(exc, msg) from exc
+    except Exception as exc:
+        raise ShopifyError(exc) from exc
 
 if __name__ == "__main__":
     main()

--- a/tap_shopify/exceptions.py
+++ b/tap_shopify/exceptions.py
@@ -1,0 +1,3 @@
+class ShopifyError(Exception):
+    def __init__(self, error, msg=''):
+        super().__init__('{}\n{}'.format(error.__class__.__name__, msg))

--- a/tap_shopify/schemas/abandoned_checkouts.json
+++ b/tap_shopify/schemas/abandoned_checkouts.json
@@ -1,7 +1,32 @@
 {
   "type": "object",
   "properties": {
-    "note_attributes": {},
+    "note_attributes": {
+      "type": [
+        "null",
+        "array"
+    ],
+    "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "value": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      }
+    },
     "location_id": {
       "type": [
         "null",
@@ -314,8 +339,30 @@
           "object"
         ],
         "properties": {
-          "applied_discounts": {},
-          "custom_tax_lines": {},
+          "applied_discounts": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": [
+                "null",
+                "object"
+              ]
+            }
+          },
+          "custom_tax_lines": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": [
+                "null",
+                "object"
+              ]
+            }
+          },
           "phone": {
             "type": [
               "null",

--- a/tap_shopify/schemas/abandoned_checkouts.json
+++ b/tap_shopify/schemas/abandoned_checkouts.json
@@ -66,8 +66,9 @@
         "latitude": {
           "type": [
             "null",
-            "number"
-          ]
+            "string"
+          ],
+          "format": "singer.decimal"
         },
         "zip": {
           "type": [
@@ -126,8 +127,9 @@
         "longitude": {
           "type": [
             "null",
-            "number"
-          ]
+            "string"
+          ],
+          "format": "singer.decimal"
         }
       }
     },
@@ -157,9 +159,9 @@
           "amount": {
             "type": [
               "null",
-              "number"
+              "string"
             ],
-            "multipleOf": 1e-10
+            "format": "singer.decimal"
           },
           "code": {
             "type": [
@@ -220,9 +222,9 @@
     "total_line_items_price": {
       "type": [
         "null",
-        "number"
+        "string"
       ],
-      "multipleOf": 1e-10
+      "format": "singer.decimal"
     },
     "closed_at": {
       "type": [
@@ -264,16 +266,16 @@
     "total_tax": {
       "type": [
         "null",
-        "number"
+        "string"
       ],
-      "multipleOf": 1e-10
+      "format": "singer.decimal"
     },
     "subtotal_price": {
       "type": [
         "null",
-        "number"
+        "string"
       ],
-      "multipleOf": 1e-10
+      "format": "singer.decimal"
     },
     "line_items": {
       "$ref": "definitions.json#/line_items"
@@ -287,9 +289,9 @@
     "total_discounts": {
       "type": [
         "null",
-        "number"
+        "string"
       ],
-      "multipleOf": 1e-10
+      "format": "singer.decimal"
     },
     "note": {
       "type": [
@@ -349,9 +351,9 @@
           "price": {
             "type": [
               "null",
-              "number"
+              "string"
             ],
-            "multipleOf": 1e-10
+            "format": "singer.decimal"
           },
           "requested_fulfillment_service_id": {
             "type": [
@@ -446,8 +448,9 @@
         "latitude": {
           "type": [
             "null",
-            "number"
-          ]
+            "string"
+          ],
+          "format": "singer.decimal"
         },
         "zip": {
           "type": [
@@ -506,8 +509,9 @@
         "longitude": {
           "type": [
             "null",
-            "number"
-          ]
+            "string"
+          ],
+          "format": "singer.decimal"
         }
       }
     },
@@ -529,9 +533,9 @@
     "total_price": {
       "type": [
         "null",
-        "number"
+        "string"
       ],
-      "multipleOf": 1e-10
+      "format": "singer.decimal"
     },
     "cart_token": {
       "type": [

--- a/tap_shopify/schemas/abandoned_checkouts.json
+++ b/tap_shopify/schemas/abandoned_checkouts.json
@@ -66,9 +66,8 @@
         "latitude": {
           "type": [
             "null",
-            "string"
-          ],
-          "format": "singer.decimal"
+            "number"
+          ]
         },
         "zip": {
           "type": [
@@ -127,9 +126,8 @@
         "longitude": {
           "type": [
             "null",
-            "string"
-          ],
-          "format": "singer.decimal"
+            "number"
+          ]
         }
       }
     },
@@ -448,9 +446,8 @@
         "latitude": {
           "type": [
             "null",
-            "string"
-          ],
-          "format": "singer.decimal"
+            "number"
+          ]
         },
         "zip": {
           "type": [
@@ -509,9 +506,8 @@
         "longitude": {
           "type": [
             "null",
-            "string"
-          ],
-          "format": "singer.decimal"
+            "number"
+          ]
         }
       }
     },

--- a/tap_shopify/schemas/definitions.json
+++ b/tap_shopify/schemas/definitions.json
@@ -485,7 +485,18 @@
   },
   "line_item": {
     "properties": {
-      "applied_discounts": {},
+      "applied_discounts": {
+        "items": {
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "type": [
+          "null",
+          "array"
+        ]
+      },
       "total_discount_set": {},
       "pre_tax_price_set": {},
       "price_set": {},

--- a/tap_shopify/schemas/definitions.json
+++ b/tap_shopify/schemas/definitions.json
@@ -476,6 +476,70 @@
           "null",
           "string"
         ]
+      },
+      "localized_province_name": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "localized_country_name": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "updated_at": {
+        "type": [
+          "null",
+          "string"
+        ],
+        "format": "date-time"
+      },
+      "province": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "phone": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "legacy": {
+        "type": [
+          "null",
+          "boolean"]
+      },
+      "created_at": {
+        "type": [
+          "null",
+          "string"
+        ],
+        "format": "date-time"
+      },
+      "country": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "active": {
+        "type": [
+          "null",
+          "boolean"]
+      },
+      "admin_graphql_api_id": {
+        "type": [
+          "null",
+          "string"]
+      },
+      "country_name": {
+        "type": [
+          "null",
+          "string"]
       }
     },
     "type": [

--- a/tap_shopify/schemas/definitions.json
+++ b/tap_shopify/schemas/definitions.json
@@ -593,9 +593,8 @@
             "amount": {
               "type": [
                 "null",
-                "string"
-              ],
-              "format": "singer.decimal"
+                "number"
+              ]
             }
           },
           "type": [
@@ -617,9 +616,8 @@
       "pre_tax_price": {
         "type": [
           "null",
-          "string"
-        ],
-        "format": "singer.decimal"
+          "number"
+        ]
       },
       "sku": {
         "type": [

--- a/tap_shopify/schemas/definitions.json
+++ b/tap_shopify/schemas/definitions.json
@@ -58,7 +58,10 @@
     ]
   },
   "customer": {
-    "type": "object",
+    "type": [
+      "null",
+      "object"
+    ],
     "properties": {
       "last_order_name": {
         "type": [

--- a/tap_shopify/schemas/definitions.json
+++ b/tap_shopify/schemas/definitions.json
@@ -11,9 +11,9 @@
         "tax_amount": {
           "type": [
             "null",
-            "number"
+            "string"
           ],
-          "multipleOf": 1e-10
+          "format": "singer.decimal"
         },
         "refund_id": {
           "type": [
@@ -24,9 +24,9 @@
         "amount": {
           "type": [
             "null",
-            "number"
+            "string"
           ],
-          "multipleOf": 1e-10
+          "format": "singer.decimal"
         },
         "kind": {
           "type": [
@@ -593,8 +593,9 @@
             "amount": {
               "type": [
                 "null",
-                "number"
-              ]
+                "string"
+              ],
+              "format": "singer.decimal"
             }
           },
           "type": [
@@ -616,8 +617,9 @@
       "pre_tax_price": {
         "type": [
           "null",
-          "number"
-        ]
+          "string"
+        ],
+        "format": "singer.decimal"
       },
       "sku": {
         "type": [
@@ -634,9 +636,9 @@
       "total_discount": {
         "type": [
           "null",
-          "number"
+          "string"
         ],
-        "multipleOf": 1e-10
+        "format": "singer.decimal"
       },
       "name": {
         "type": [
@@ -680,9 +682,9 @@
       "price": {
         "type": [
           "null",
-          "number"
+          "string"
         ],
-        "multipleOf": 1e-10
+        "format": "singer.decimal"
       },
       "requires_shipping": {
         "type": [
@@ -828,9 +830,9 @@
         "price": {
           "type": [
             "null",
-            "number"
+            "string"
           ],
-          "multipleOf": 1e-10
+          "format": "singer.decimal"
         },
         "title": {
           "type": [
@@ -841,9 +843,9 @@
         "rate": {
           "type": [
             "null",
-            "number"
+            "string"
           ],
-          "multipleOf": 1e-10
+          "format": "singer.decimal"
         },
         "compare_at": {
           "type": [

--- a/tap_shopify/schemas/events.json
+++ b/tap_shopify/schemas/events.json
@@ -1,0 +1,60 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "created_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "body": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "path": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "message": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+     "subject_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "subject_type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "verb": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "author": {
+      "type": [
+        "null",
+        "string"
+      ]
+    }
+  }
+}

--- a/tap_shopify/schemas/inventory_items.json
+++ b/tap_shopify/schemas/inventory_items.json
@@ -1,0 +1,100 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "sku": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "created_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "requires_shipping": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "cost": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "country_code_of_origin": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "province_code_of_origin": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "harmonized_system_code": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "tracked": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "country_harmonized_system_codes": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "harmonized_system_code": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "country_code": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      }
+    },
+    "admin_graphql_api_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    }
+  }
+}

--- a/tap_shopify/schemas/inventory_levels.json
+++ b/tap_shopify/schemas/inventory_levels.json
@@ -1,0 +1,21 @@
+{
+  "properties": {
+    "available": {
+      "type": ["null", "integer"]
+    },
+    "inventory_item_id": {
+      "type": ["null", "integer"]
+    },
+    "updated_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "location_id": {
+      "type": ["null", "integer"]
+    },
+    "admin_graphql_api_id": {
+      "type": ["null", "string"]
+    }
+  },
+  "type": "object"
+}

--- a/tap_shopify/schemas/locations.json
+++ b/tap_shopify/schemas/locations.json
@@ -1,0 +1,3 @@
+{
+  "$ref": "definitions.json#/location"
+}

--- a/tap_shopify/schemas/order_refunds.json
+++ b/tap_shopify/schemas/order_refunds.json
@@ -168,8 +168,9 @@
           "total_tax": {
             "type": [
               "null",
-              "number"
-            ]
+              "string"
+            ],
+            "format": "singer.decimal"
           },
           "quantity": {
             "type": [
@@ -267,8 +268,9 @@
                     "rate": {
                       "type": [
                         "null",
-                        "number"
-                      ]
+                        "string"
+                      ],
+                      "format": "singer.decimal"
                     }
                   },
                   "type": [
@@ -650,8 +652,9 @@
           "subtotal": {
             "type": [
               "null",
-              "number"
-            ]
+              "string"
+            ],
+            "format": "singer.decimal"
           },
           "restock_type": {
             "type": [

--- a/tap_shopify/schemas/order_refunds.json
+++ b/tap_shopify/schemas/order_refunds.json
@@ -168,9 +168,8 @@
           "total_tax": {
             "type": [
               "null",
-              "string"
-            ],
-            "format": "singer.decimal"
+              "number"
+            ]
           },
           "quantity": {
             "type": [
@@ -268,9 +267,8 @@
                     "rate": {
                       "type": [
                         "null",
-                        "string"
-                      ],
-                      "format": "singer.decimal"
+                        "number"
+                      ]
                     }
                   },
                   "type": [
@@ -652,9 +650,8 @@
           "subtotal": {
             "type": [
               "null",
-              "string"
-            ],
-            "format": "singer.decimal"
+              "number"
+            ]
           },
           "restock_type": {
             "type": [

--- a/tap_shopify/schemas/orders.json
+++ b/tap_shopify/schemas/orders.json
@@ -1,4 +1,4 @@
-{
+ {
   "properties": {
     "presentment_currency": {
         "type": [
@@ -15,9 +15,9 @@
     "total_price": {
       "type": [
         "null",
-        "number"
+        "string"
       ],
-      "multipleOf": 1e-10
+      "format": "singer.decimal"
     },
     "line_items": {
       "$ref": "definitions.json#/line_items"
@@ -43,16 +43,16 @@
     "total_discounts": {
       "type": [
         "null",
-        "number"
+        "string"
       ],
-      "multipleOf": 1e-10
+      "format": "singer.decimal"
     },
     "total_line_items_price": {
       "type": [
         "null",
-        "number"
+        "string"
       ],
-      "multipleOf": 1e-10
+      "format": "singer.decimal"
     },
     "order_adjustments": {
       "$ref": "definitions.json#/order_adjustments"
@@ -74,9 +74,9 @@
           "price": {
             "type": [
               "null",
-              "number"
+              "string"
             ],
-            "multipleOf": 1e-10
+            "format": "singer.decimal"
           },
           "title": {
             "type": [
@@ -96,8 +96,9 @@
                 "amount": {
                   "type": [
                     "null",
-                    "number"
-                  ]
+                    "string"
+                  ],
+                  "format": "singer.decimal"
                 }
               },
               "type": [
@@ -119,8 +120,9 @@
           "discounted_price": {
             "type": [
               "null",
-              "number"
-            ]
+              "string"
+            ],
+            "format": "singer.decimal"
           },
           "code": {
             "type": [
@@ -374,9 +376,9 @@
     "total_tax": {
       "type": [
         "null",
-        "number"
+        "string"
       ],
-      "multipleOf": 1e-10
+      "format": "singer.decimal"
     },
     "payment_details": {
       "properties": {
@@ -469,8 +471,9 @@
         "longitude": {
           "type": [
             "null",
-            "number"
-          ]
+            "string"
+          ],
+          "format": "singer.decimal"
         },
         "address2": {
           "type": [
@@ -511,8 +514,9 @@
         "latitude": {
           "type": [
             "null",
-            "number"
-          ]
+            "string"
+          ],
+          "format": "singer.decimal"
         },
         "country_code": {
           "type": [
@@ -541,9 +545,9 @@
     "total_price_usd": {
       "type": [
         "null",
-        "number"
+        "string"
       ],
-      "multipleOf": 1e-10
+      "format": "singer.decimal"
     },
     "closed_at": {
       "type": [
@@ -606,8 +610,9 @@
           "value": {
             "type": [
               "null",
-              "number"
-            ]
+              "string"
+            ],
+            "format": "singer.decimal"
           }
         },
         "type": [
@@ -647,9 +652,9 @@
     "subtotal_price": {
       "type": [
         "null",
-        "number"
+        "string"
       ],
-      "multipleOf": 1e-10
+      "format": "singer.decimal"
     },
     "billing_address": {
       "properties": {
@@ -680,8 +685,9 @@
         "longitude": {
           "type": [
             "null",
-            "number"
-          ]
+            "string"
+          ],
+          "format": "singer.decimal"
         },
         "address2": {
           "type": [
@@ -722,8 +728,9 @@
         "latitude": {
           "type": [
             "null",
-            "number"
-          ]
+            "string"
+          ],
+          "format": "singer.decimal"
         },
         "country_code": {
           "type": [
@@ -797,9 +804,9 @@
           "amount": {
             "type": [
               "null",
-              "number"
+              "string"
             ],
-            "multipleOf": 1e-10
+            "format": "singer.decimal"
           },
           "type": {
             "type": [
@@ -1012,8 +1019,9 @@
                 "total_tax": {
                   "type": [
                     "null",
-                    "number"
-                  ]
+                    "string"
+                  ],
+                  "format": "singer.decimal"
                 },
                 "restock_type": {
                   "type": [
@@ -1024,8 +1032,9 @@
                 "subtotal": {
                   "type": [
                     "null",
-                    "number"
-                  ]
+                    "string"
+                  ],
+                  "format": "singer.decimal"
                 }
               },
               "type": [

--- a/tap_shopify/schemas/orders.json
+++ b/tap_shopify/schemas/orders.json
@@ -1,4 +1,4 @@
- {
+{
   "properties": {
     "presentment_currency": {
         "type": [
@@ -96,9 +96,8 @@
                 "amount": {
                   "type": [
                     "null",
-                    "string"
-                  ],
-                  "format": "singer.decimal"
+                    "number"
+                  ]
                 }
               },
               "type": [
@@ -120,9 +119,8 @@
           "discounted_price": {
             "type": [
               "null",
-              "string"
-            ],
-            "format": "singer.decimal"
+              "number"
+            ]
           },
           "code": {
             "type": [
@@ -471,9 +469,8 @@
         "longitude": {
           "type": [
             "null",
-            "string"
-          ],
-          "format": "singer.decimal"
+            "number"
+          ]
         },
         "address2": {
           "type": [
@@ -514,9 +511,8 @@
         "latitude": {
           "type": [
             "null",
-            "string"
-          ],
-          "format": "singer.decimal"
+            "number"
+          ]
         },
         "country_code": {
           "type": [
@@ -610,9 +606,8 @@
           "value": {
             "type": [
               "null",
-              "string"
-            ],
-            "format": "singer.decimal"
+              "number"
+            ]
           }
         },
         "type": [
@@ -685,9 +680,8 @@
         "longitude": {
           "type": [
             "null",
-            "string"
-          ],
-          "format": "singer.decimal"
+            "number"
+          ]
         },
         "address2": {
           "type": [
@@ -728,9 +722,8 @@
         "latitude": {
           "type": [
             "null",
-            "string"
-          ],
-          "format": "singer.decimal"
+            "number"
+          ]
         },
         "country_code": {
           "type": [
@@ -1019,9 +1012,8 @@
                 "total_tax": {
                   "type": [
                     "null",
-                    "string"
-                  ],
-                  "format": "singer.decimal"
+                    "number"
+                  ]
                 },
                 "restock_type": {
                   "type": [
@@ -1032,9 +1024,8 @@
                 "subtotal": {
                   "type": [
                     "null",
-                    "string"
-                  ],
-                  "format": "singer.decimal"
+                    "number"
+                  ]
                 }
               },
               "type": [

--- a/tap_shopify/schemas/products.json
+++ b/tap_shopify/schemas/products.json
@@ -1,5 +1,11 @@
 {
   "properties": {
+    "status": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "published_at": {
       "type": [
         "null",

--- a/tap_shopify/schemas/products.json
+++ b/tap_shopify/schemas/products.json
@@ -221,9 +221,8 @@
           "weight": {
             "type": [
               "null",
-              "string"
-            ],
-            "format": "singer.decimal"
+              "number"
+            ]
           },
           "inventory_management": {
             "type": [

--- a/tap_shopify/schemas/products.json
+++ b/tap_shopify/schemas/products.json
@@ -178,9 +178,9 @@
           "price": {
             "type": [
               "null",
-              "number"
+              "string"
             ],
-            "multipleOf": 1e-10
+            "format": "singer.decimal"
           },
           "image_id": {
             "type": [
@@ -221,8 +221,9 @@
           "weight": {
             "type": [
               "null",
-              "number"
-            ]
+              "string"
+            ],
+            "format": "singer.decimal"
           },
           "inventory_management": {
             "type": [
@@ -251,9 +252,9 @@
           "compare_at_price": {
             "type": [
               "null",
-              "number"
+              "string"
             ],
-            "multipleOf": 1e-10
+            "format": "singer.decimal"
           },
           "updated_at": {
             "type": [

--- a/tap_shopify/schemas/transactions.json
+++ b/tap_shopify/schemas/transactions.json
@@ -45,9 +45,9 @@
     "amount": {
       "type": [
         "null",
-        "number"
+        "string"
       ],
-      "multipleOf": 1e-10
+      "format": "singer.decimal"
     },
     "authorization": {
       "type": [
@@ -150,23 +150,23 @@
         "fee_amount": {
           "type": [
             "null",
-            "number"
+            "string"
           ],
-          "multipleOf": 1e-10
+          "format": "singer.decimal"
         },
         "gross_amount": {
           "type": [
             "null",
-            "number"
+            "string"
           ],
-          "multipleOf": 1e-10
+          "format": "singer.decimal"
         },
         "tax_amount": {
           "type": [
             "null",
-            "number"
+            "string"
           ],
-          "multipleOf": 1e-10
+          "format": "singer.decimal"
         }
       },
       "patternProperties": {".+": {}}

--- a/tap_shopify/streams/__init__.py
+++ b/tap_shopify/streams/__init__.py
@@ -7,3 +7,4 @@ import tap_shopify.streams.transactions
 import tap_shopify.streams.products
 import tap_shopify.streams.collects
 import tap_shopify.streams.custom_collections
+import tap_shopify.streams.inventory_items

--- a/tap_shopify/streams/__init__.py
+++ b/tap_shopify/streams/__init__.py
@@ -10,3 +10,4 @@ import tap_shopify.streams.custom_collections
 import tap_shopify.streams.locations
 import tap_shopify.streams.inventory_levels
 import tap_shopify.streams.inventory_items
+import tap_shopify.streams.events

--- a/tap_shopify/streams/__init__.py
+++ b/tap_shopify/streams/__init__.py
@@ -7,4 +7,6 @@ import tap_shopify.streams.transactions
 import tap_shopify.streams.products
 import tap_shopify.streams.collects
 import tap_shopify.streams.custom_collections
+import tap_shopify.streams.locations
+import tap_shopify.streams.inventory_levels
 import tap_shopify.streams.inventory_items

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -37,7 +37,7 @@ def is_not_status_code_fn(status_code):
 
 def leaky_bucket_handler(details):
     LOGGER.info("Received 429 -- sleeping for %s seconds",
-                details['wait'])
+                details.get('wait', '5'))
 
 def retry_handler(details):
     LOGGER.info("Received 500 or retryable error -- Retry %s/%s",
@@ -52,7 +52,7 @@ def retry_after_wait_gen(**kwargs):
     # Retry-After is an undocumented header. But honoring
     # it was proven to work in our spikes.
     # It's been observed to come through as lowercase, so fallback if not present
-    sleep_time_str = resp.headers.get('Retry-After', resp.headers.get('retry-after'))
+    sleep_time_str = resp.headers.get('Retry-After', resp.headers.get('retry-after', '5.0'))
     yield math.floor(float(sleep_time_str))
 
 def shopify_error_handling(fnc):

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -68,7 +68,7 @@ def shopify_error_handling(fnc):
                            TimeoutError,
                            urllib.error.URLError,
                           ),
-                          giveup=is_not_status_code_fn(range(500, 599)),
+                          giveup=is_not_status_code_fn(list(range(500, 599)) + [429]),
                           on_backoff=retry_handler,
                           max_tries=MAX_RETRIES,
                           factor=FACTOR)

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -153,7 +153,9 @@ class Stream():
                 query_params = {
                     "since_id": since_id,
                     "updated_at_min": updated_at_min,
+                    "created_at_min": updated_at_min, # For events, which requires the `created_at_min` query param for filtering
                     "updated_at_max": updated_at_max,
+                    "created_at_max": updated_at_max,
                     "limit": self.results_per_page,
                     status_key: "any"
                 }

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -2,7 +2,7 @@ import datetime
 import functools
 import math
 import sys
-
+import socket
 import backoff
 import pyactiveresource
 import pyactiveresource.formats
@@ -15,12 +15,27 @@ LOGGER = singer.get_logger()
 
 RESULTS_PER_PAGE = 175
 
+# set default timeout of 300 seconds
+REQUEST_TIMEOUT = 300
+
 # We've observed 500 errors returned if this is too large (30 days was too
 # large for a customer)
 DATE_WINDOW_SIZE = 1
 
 # We will retry a 500 error a maximum of 5 times before giving up
 MAX_RETRIES = 5
+
+# function to return request timeout
+def get_request_timeout():
+
+    request_timeout = REQUEST_TIMEOUT # set default timeout
+    timeout_from_config = Context.config.get('request_timeout')
+    # updated the timeout value if timeout is passed in config and not from 0, "0", ""
+    if timeout_from_config and float(timeout_from_config):
+        # update the request timeout for the requests
+        request_timeout = float(timeout_from_config)
+
+    return request_timeout
 
 def is_not_status_code_fn(status_code):
     def gen_fn(exc):
@@ -50,7 +65,23 @@ def retry_after_wait_gen(**kwargs):
     sleep_time_str = resp.headers.get('Retry-After', resp.headers.get('retry-after'))
     yield math.floor(float(sleep_time_str))
 
+# boolean function to check if the error is 'timeout' error or not
+def is_timeout_error(error_raised):
+    """
+        This function checks whether the error contains 'timed out' substring and return boolean
+        values accordingly, to decide whether to backoff or not.
+    """
+    # retry if the error string contains 'timed out'
+    if str(error_raised).__contains__('timed out'):
+        return False
+    return True
+
 def shopify_error_handling(fnc):
+    @backoff.on_exception(backoff.expo, # timeout error raise by Shopify
+                          (pyactiveresource.connection.Error, socket.timeout),
+                          giveup=is_timeout_error,
+                          max_tries=MAX_RETRIES,
+                          factor=2)
     @backoff.on_exception(backoff.expo,
                           (pyactiveresource.connection.ServerError,
                            pyactiveresource.formats.Error,
@@ -91,6 +122,9 @@ class Stream():
     def __init__(self):
         self.results_per_page = Context.get_results_per_page(RESULTS_PER_PAGE)
 
+        # set request timeout
+        self.request_timeout = get_request_timeout()
+
     def get_bookmark(self):
         bookmark = (singer.get_bookmark(Context.state,
                                         # name is overridden by some substreams
@@ -124,6 +158,8 @@ class Stream():
     # with shopify_error_handling to get 429 and 500 handling.
     @shopify_error_handling
     def call_api(self, query_params):
+        # set timeout
+        self.replication_object.set_timeout(self.request_timeout)
         return self.replication_object.find(**query_params)
 
     def get_query_params(self, since_id, status_key, updated_at_min, updated_at_max):

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -86,6 +86,10 @@ class Stream():
     replication_object = None
     # Status parameter override option
     status_key = None
+    results_per_page = None
+
+    def __init__(self):
+        self.results_per_page = Context.get_results_per_page(RESULTS_PER_PAGE)
 
     def get_bookmark(self):
         bookmark = (singer.get_bookmark(Context.state,
@@ -127,7 +131,6 @@ class Stream():
 
         stop_time = singer.utils.now().replace(microsecond=0)
         date_window_size = float(Context.config.get("date_window_size", DATE_WINDOW_SIZE))
-        results_per_page = Context.get_results_per_page(RESULTS_PER_PAGE)
 
         # Page through till the end of the resultset
         while updated_at_min < stop_time:
@@ -151,7 +154,7 @@ class Stream():
                     "since_id": since_id,
                     "updated_at_min": updated_at_min,
                     "updated_at_max": updated_at_max,
-                    "limit": results_per_page,
+                    "limit": self.results_per_page,
                     status_key: "any"
                 }
 
@@ -169,7 +172,7 @@ class Stream():
 
                 # You know you're at the end when the current page has
                 # less than the request size limits you set.
-                if len(objects) < results_per_page:
+                if len(objects) < self.results_per_page:
                     # Save the updated_at_max as our bookmark as we've synced all rows up in our
                     # window and can move forward. Also remove the since_id because we want to
                     # restart at 1.

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -126,6 +126,15 @@ class Stream():
     def call_api(self, query_params):
         return self.replication_object.find(**query_params)
 
+    def get_query_params(self, since_id, status_key, updated_at_min, updated_at_max):
+        return {
+            "since_id": since_id,
+            "updated_at_min": updated_at_min,
+            "updated_at_max": updated_at_max,
+            "limit": self.results_per_page,
+            status_key: "any"
+        }
+
     def get_objects(self):
         updated_at_min = self.get_bookmark()
 
@@ -150,15 +159,10 @@ class Stream():
                 updated_at_max = stop_time
             while True:
                 status_key = self.status_key or "status"
-                query_params = {
-                    "since_id": since_id,
-                    "updated_at_min": updated_at_min,
-                    "created_at_min": updated_at_min, # For events, which requires the `created_at_min` query param for filtering
-                    "updated_at_max": updated_at_max,
-                    "created_at_max": updated_at_max,
-                    "limit": self.results_per_page,
-                    status_key: "any"
-                }
+                query_params = self.get_query_params(since_id,
+                                                     status_key,
+                                                     updated_at_min,
+                                                     updated_at_max)
 
                 with metrics.http_request_timer(self.name):
                     objects = self.call_api(query_params)

--- a/tap_shopify/streams/collects.py
+++ b/tap_shopify/streams/collects.py
@@ -2,7 +2,6 @@ import shopify
 import singer
 from singer import utils
 from tap_shopify.streams.base import (Stream,
-                                      RESULTS_PER_PAGE,
                                       OutOfOrderIdsError)
 from tap_shopify.context import Context
 
@@ -20,7 +19,7 @@ class Collects(Stream):
         while True:
             query_params = {
                 "since_id": since_id,
-                "limit": RESULTS_PER_PAGE,
+                "limit": self.results_per_page,
             }
 
             objects = self.call_api(query_params)
@@ -38,7 +37,7 @@ class Collects(Stream):
                             obj.id, since_id))
                     yield obj
 
-            if len(objects) < RESULTS_PER_PAGE:
+            if len(objects) < self.results_per_page:
                 # Update the bookmark at the end of the last page
                 self.update_bookmark(max_bookmark)
                 break

--- a/tap_shopify/streams/events.py
+++ b/tap_shopify/streams/events.py
@@ -1,0 +1,12 @@
+import shopify
+
+from tap_shopify.streams.base import Stream
+from tap_shopify.context import Context
+
+
+class Events(Stream):
+    name = 'events'
+    replication_object = shopify.Event
+    replication_key = "created_at"
+
+Context.stream_objects['events'] = Events

--- a/tap_shopify/streams/events.py
+++ b/tap_shopify/streams/events.py
@@ -9,4 +9,13 @@ class Events(Stream):
     replication_object = shopify.Event
     replication_key = "created_at"
 
+    def get_query_params(self, since_id, status_key, updated_at_min, updated_at_max):
+        return {
+            "since_id": since_id,
+            "created_at_min": updated_at_min,
+            "created_at_max": updated_at_max,
+            "limit": self.results_per_page,
+            status_key: "any"
+        }
+
 Context.stream_objects['events'] = Events

--- a/tap_shopify/streams/inventory_items.py
+++ b/tap_shopify/streams/inventory_items.py
@@ -1,0 +1,54 @@
+import singer
+import shopify
+from singer.utils import strftime,strptime_to_utc
+from tap_shopify.streams.base import (Stream, shopify_error_handling)
+from tap_shopify.context import Context
+
+LOGGER = singer.get_logger()
+
+RESULTS_PER_PAGE = 250
+
+class InventoryItems(Stream):
+    name = 'inventory_items'
+    replication_object = shopify.InventoryItem
+
+    @shopify_error_handling
+    def get_inventory_items(self, inventory_items_ids):
+        return self.replication_object.find(
+            ids=inventory_items_ids,
+            limit=RESULTS_PER_PAGE)
+
+    def get_objects(self):
+
+        selected_parent = Context.stream_objects['products']()
+        selected_parent.name = "product_variants"
+
+        # Page through all `products`, bookmarking at `product_variants`
+        for parent_object in selected_parent.get_objects():
+
+            product_variants = parent_object.variants
+            inventory_items_ids = ",".join(
+                [str(product_variant.inventory_item_id) for product_variant in product_variants])
+
+            # Max limit of IDs is 100 and Max limit of product_variants in one product is also 100
+            # hence we can directly pass all inventory_items_ids
+            inventory_items = self.get_inventory_items(inventory_items_ids)
+
+            for inventory_item in inventory_items:
+                yield inventory_item
+
+    def sync(self):
+        bookmark = self.get_bookmark()
+        max_bookmark = bookmark
+        for inventory_item in self.get_objects():
+            inventory_item_dict = inventory_item.to_dict()
+            replication_value = strptime_to_utc(inventory_item_dict[self.replication_key])
+            if replication_value >= bookmark:
+                yield inventory_item_dict
+
+            if replication_value > max_bookmark:
+                max_bookmark = replication_value
+
+        self.update_bookmark(strftime(max_bookmark))
+
+Context.stream_objects['inventory_items'] = InventoryItems

--- a/tap_shopify/streams/inventory_items.py
+++ b/tap_shopify/streams/inventory_items.py
@@ -14,6 +14,8 @@ class InventoryItems(Stream):
 
     @shopify_error_handling
     def get_inventory_items(self, inventory_items_ids):
+        # set timeout
+        self.replication_object.set_timeout(self.request_timeout)
         return self.replication_object.find(
             ids=inventory_items_ids,
             limit=RESULTS_PER_PAGE)

--- a/tap_shopify/streams/inventory_levels.py
+++ b/tap_shopify/streams/inventory_levels.py
@@ -1,0 +1,57 @@
+import shopify
+from singer.utils import strftime, strptime_to_utc
+from tap_shopify.streams.base import (Stream,
+                                      RESULTS_PER_PAGE,
+                                      shopify_error_handling)
+from tap_shopify.context import Context
+
+class InventoryLevels(Stream):
+    name = 'inventory_levels'
+    replication_key = 'updated_at'
+    key_properties = ['location_id', 'inventory_item_id']
+    replication_object = shopify.InventoryLevel
+
+    @shopify_error_handling
+    def api_call_for_inventory_levels(self, parent_object_id, bookmark):
+        return self.replication_object.find(
+            updated_at_min = bookmark,
+            limit = RESULTS_PER_PAGE,
+            location_ids=parent_object_id
+        )
+
+    def get_inventory_levels(self, parent_object, bookmark):
+        inventory_page = self.api_call_for_inventory_levels(parent_object, bookmark)
+        yield from inventory_page
+
+        while inventory_page.has_next_page():
+            inventory_page = inventory_page.next_page()
+            yield from inventory_page
+
+    def get_objects(self):
+        bookmark = self.get_bookmark()
+
+        selected_parent = Context.stream_objects['locations']()
+        selected_parent.name = "inventory_level_locations"
+
+        # Get all locations data as location id is used for Inventory Level
+        # If we get locations updated after a bookmark
+        # then there is possibility of data loss for Inventory Level
+        # because location is not updated when any Inventory Level is updated inside it.
+        for parent_object in selected_parent.get_locations_data():
+            yield from self.get_inventory_levels(parent_object.id, bookmark)
+
+    def sync(self):
+        bookmark = self.get_bookmark()
+        max_bookmark = bookmark
+        for inventory_level in self.get_objects():
+            inventory_level_dict = inventory_level.to_dict()
+            replication_value = strptime_to_utc(inventory_level_dict[self.replication_key])
+            if replication_value >= bookmark:
+                yield inventory_level_dict
+
+            if replication_value > max_bookmark:
+                max_bookmark = replication_value
+
+        self.update_bookmark(strftime(max_bookmark))
+
+Context.stream_objects['inventory_levels'] = InventoryLevels

--- a/tap_shopify/streams/inventory_levels.py
+++ b/tap_shopify/streams/inventory_levels.py
@@ -10,9 +10,12 @@ class InventoryLevels(Stream):
     replication_key = 'updated_at'
     key_properties = ['location_id', 'inventory_item_id']
     replication_object = shopify.InventoryLevel
+    # Added decorator over functions of shopify SDK
+    replication_object.find = shopify_error_handling(replication_object.find)
 
-    @shopify_error_handling
     def api_call_for_inventory_levels(self, parent_object_id, bookmark):
+        # set timeout
+        self.replication_object.set_timeout(self.request_timeout)
         return self.replication_object.find(
             updated_at_min = bookmark,
             limit = RESULTS_PER_PAGE,

--- a/tap_shopify/streams/locations.py
+++ b/tap_shopify/streams/locations.py
@@ -1,0 +1,37 @@
+import shopify
+from singer import utils
+from tap_shopify.streams.base import (Stream, shopify_error_handling)
+from tap_shopify.context import Context
+
+class Locations(Stream):
+    name = 'locations'
+    replication_object = shopify.Location
+
+    @shopify_error_handling
+    def get_locations_data(self):
+        location_page = self.replication_object.find()
+        yield from location_page
+
+        while location_page.has_next_page():
+            location_page = location_page.next_page()
+            yield from location_page
+
+    def sync(self):
+        bookmark = self.get_bookmark()
+        max_bookmark = bookmark
+
+        for location in self.get_locations_data():
+
+            location_dict = location.to_dict()
+            replication_value = utils.strptime_to_utc(location_dict[self.replication_key])
+
+            if replication_value >= bookmark:
+                yield location_dict
+
+            # update max bookmark if "replication_value" of current location is greater
+            if replication_value > max_bookmark:
+                max_bookmark = replication_value
+
+        self.update_bookmark(utils.strftime(max_bookmark))
+
+Context.stream_objects['locations'] = Locations

--- a/tap_shopify/streams/locations.py
+++ b/tap_shopify/streams/locations.py
@@ -6,9 +6,12 @@ from tap_shopify.context import Context
 class Locations(Stream):
     name = 'locations'
     replication_object = shopify.Location
+    # Added decorator over functions of shopify SDK
+    replication_object.find = shopify_error_handling(replication_object.find)
 
-    @shopify_error_handling
     def get_locations_data(self):
+        # set timeout
+        self.replication_object.set_timeout(self.request_timeout)
         location_page = self.replication_object.find()
         yield from location_page
 

--- a/tap_shopify/streams/metafields.py
+++ b/tap_shopify/streams/metafields.py
@@ -20,7 +20,7 @@ def get_metafields(parent_object, since_id):
     # This call results in an HTTP request - the parent object never has a
     # cache of this data so we have to issue that request.
     return parent_object.metafields(
-        limit=RESULTS_PER_PAGE,
+        limit=Context.get_results_per_page(RESULTS_PER_PAGE),
         since_id=since_id)
 
 class Metafields(Stream):
@@ -46,7 +46,7 @@ class Metafields(Stream):
                             raise OutOfOrderIdsError("metafield.id < since_id: {} < {}".format(
                                 metafield.id, since_id))
                         yield metafield
-                    if len(metafields) < RESULTS_PER_PAGE:
+                    if len(metafields) < self.results_per_page:
                         break
                     if metafields[-1].id != max([o.id for o in metafields]):
                         raise OutOfOrderIdsError("{} is not the max id in metafields ({})".format(

--- a/tap_shopify/streams/metafields.py
+++ b/tap_shopify/streams/metafields.py
@@ -16,7 +16,9 @@ def get_selected_parents():
             yield Context.stream_objects[parent_stream]()
 
 @shopify_error_handling
-def get_metafields(parent_object, since_id):
+def get_metafields(parent_object, since_id, parent_replication_object, timeout):
+    # set timeout
+    parent_replication_object.set_timeout(timeout)
     # This call results in an HTTP request - the parent object never has a
     # cache of this data so we have to issue that request.
     return parent_object.metafields(
@@ -40,7 +42,10 @@ class Metafields(Stream):
             for parent_object in selected_parent.get_objects():
                 since_id = 1
                 while True:
-                    metafields = get_metafields(parent_object, since_id)
+                    metafields = get_metafields(parent_object,
+                                                since_id,
+                                                selected_parent.replication_object,
+                                                self.request_timeout)
                     for metafield in metafields:
                         if metafield.id < since_id:
                             raise OutOfOrderIdsError("metafield.id < since_id: {} < {}".format(

--- a/tap_shopify/streams/order_refunds.py
+++ b/tap_shopify/streams/order_refunds.py
@@ -2,7 +2,6 @@ import shopify
 from singer.utils import strftime, strptime_to_utc
 from tap_shopify.context import Context
 from tap_shopify.streams.base import (Stream,
-                                      RESULTS_PER_PAGE,
                                       shopify_error_handling,
                                       OutOfOrderIdsError)
 
@@ -15,7 +14,7 @@ class OrderRefunds(Stream):
     def get_refunds(self, parent_object, since_id):
         return self.replication_object.find(
             order_id=parent_object.id,
-            limit=RESULTS_PER_PAGE,
+            limit=self.results_per_page,
             since_id=since_id,
             order='id asc')
 
@@ -33,7 +32,7 @@ class OrderRefunds(Stream):
                         raise OutOfOrderIdsError("refund.id < since_id: {} < {}".format(
                             refund.id, since_id))
                     yield refund
-                if len(refunds) < RESULTS_PER_PAGE:
+                if len(refunds) < self.results_per_page:
                     break
                 if refunds[-1].id != max([o.id for o in refunds]):
                     raise OutOfOrderIdsError("{} is not the max id in refunds ({})".format(

--- a/tap_shopify/streams/order_refunds.py
+++ b/tap_shopify/streams/order_refunds.py
@@ -1,11 +1,10 @@
 import shopify
-
+from singer.utils import strftime, strptime_to_utc
 from tap_shopify.context import Context
 from tap_shopify.streams.base import (Stream,
                                       RESULTS_PER_PAGE,
                                       shopify_error_handling,
                                       OutOfOrderIdsError)
-
 
 class OrderRefunds(Stream):
     name = 'order_refunds'
@@ -42,8 +41,18 @@ class OrderRefunds(Stream):
                 since_id = refunds[-1].id
 
     def sync(self):
+        bookmark = self.get_bookmark()
+        max_bookmark = bookmark
         for refund in self.get_objects():
             refund_dict = refund.to_dict()
-            yield refund_dict
+            replication_value = strptime_to_utc(refund_dict[self.replication_key])
+            if replication_value >= bookmark:
+                yield refund_dict
+
+            if replication_value > max_bookmark:
+                max_bookmark = replication_value
+
+        self.update_bookmark(strftime(max_bookmark))
+
 
 Context.stream_objects['order_refunds'] = OrderRefunds

--- a/tap_shopify/streams/order_refunds.py
+++ b/tap_shopify/streams/order_refunds.py
@@ -12,6 +12,8 @@ class OrderRefunds(Stream):
 
     @shopify_error_handling
     def get_refunds(self, parent_object, since_id):
+        # set timeout
+        self.replication_object.set_timeout(self.request_timeout)
         return self.replication_object.find(
             order_id=parent_object.id,
             limit=self.results_per_page,

--- a/tap_shopify/streams/transactions.py
+++ b/tap_shopify/streams/transactions.py
@@ -57,12 +57,15 @@ class Transactions(Stream):
     name = 'transactions'
     replication_key = 'created_at'
     replication_object = shopify.Transaction
+    # Added decorator over functions of shopify SDK
+    replication_object.find = shopify_error_handling(replication_object.find)
     # Transactions have no updated_at property. Therefore we have
     # nothing to set the `replication_method` member to.
     # https://help.shopify.com/en/api/reference/orders/transaction#properties
 
-    @shopify_error_handling
     def call_api_for_transactions(self, parent_object):
+        # set timeout
+        self.replication_object.set_timeout(self.request_timeout)
         return self.replication_object.find(
             limit=TRANSACTIONS_RESULTS_PER_PAGE,
             order_id=parent_object.id,

--- a/tap_shopify/streams/transactions.py
+++ b/tap_shopify/streams/transactions.py
@@ -105,7 +105,7 @@ class Transactions(Stream):
             transaction_dict = transaction.to_dict()
             replication_value = strptime_to_utc(transaction_dict[self.replication_key])
             if replication_value >= bookmark:
-                for field_name in ['token', 'version', 'ack', 'timestamp']:
+                for field_name in ['token', 'version', 'ack', 'timestamp', 'build']:
                     canonicalize(transaction_dict, field_name)
                 yield transaction_dict
 

--- a/tap_shopify/streams/transactions.py
+++ b/tap_shopify/streams/transactions.py
@@ -1,5 +1,6 @@
 import shopify
 import singer
+from singer.utils import strftime, strptime_to_utc
 from tap_shopify.context import Context
 from tap_shopify.streams.base import (Stream,
                                       shopify_error_handling)
@@ -56,6 +57,12 @@ class Transactions(Stream):
     # https://help.shopify.com/en/api/reference/orders/transaction#properties
 
     @shopify_error_handling
+    def call_api_for_transactions(self, parent_object):
+        return self.replication_object.find(
+            limit=TRANSACTIONS_RESULTS_PER_PAGE,
+            order_id=parent_object.id,
+        )
+
     def get_transactions(self, parent_object):
         # We do not need to support paging on this substream. If that
         # were to become untrue, reference Metafields.
@@ -65,8 +72,13 @@ class Transactions(Stream):
         # support limit overrides.
         #
         # https://github.com/Shopify/shopify_python_api/blob/e8c475ccc84b1516912b37f691d00ecd24921e9b/shopify/resources/order.py#L17-L18
-        return self.replication_object.find(
-            limit=TRANSACTIONS_RESULTS_PER_PAGE, order_id=parent_object.id)
+
+        page = self.call_api_for_transactions(parent_object)
+        yield from page
+
+        while page.has_next_page():
+            page = page.next_page()
+            yield from page
 
     def get_objects(self):
         # Right now, it's ok for the user to select 'transactions' but not
@@ -87,10 +99,19 @@ class Transactions(Stream):
                 yield transaction
 
     def sync(self):
+        bookmark = self.get_bookmark()
+        max_bookmark = bookmark
         for transaction in self.get_objects():
             transaction_dict = transaction.to_dict()
-            for field_name in ['token', 'version', 'ack']:
-                canonicalize(transaction_dict, field_name)
-            yield transaction_dict
+            replication_value = strptime_to_utc(transaction_dict[self.replication_key])
+            if replication_value >= bookmark:
+                for field_name in ['token', 'version', 'ack']:
+                    canonicalize(transaction_dict, field_name)
+                yield transaction_dict
+
+            if replication_value > max_bookmark:
+                max_bookmark = replication_value
+
+        self.update_bookmark(strftime(max_bookmark))
 
 Context.stream_objects['transactions'] = Transactions

--- a/tap_shopify/streams/transactions.py
+++ b/tap_shopify/streams/transactions.py
@@ -23,29 +23,34 @@ TRANSACTIONS_RESULTS_PER_PAGE = 100
 # their values are not equal
 def canonicalize(transaction_dict, field_name):
     field_name_upper = field_name.capitalize()
-    value_lower = transaction_dict.get('receipt', {}).get(field_name)
-    value_upper = transaction_dict.get('receipt', {}).get(field_name_upper)
-    if value_lower and value_upper:
-        if value_lower == value_upper:
-            LOGGER.info((
-                "Transaction (id=%d) contains a receipt "
-                "that has `%s` and `%s` keys with the same "
-                "value. Removing the `%s` key."),
+    # Not all Shopify transactions have receipts. Facebook has been shown
+    # to push a null receipt through the transaction
+    receipt = transaction_dict.get('receipt', {})
+    if receipt:
+        value_lower = receipt.get(field_name)
+        value_upper = receipt.get(field_name_upper)
+        if value_lower and value_upper:
+            if value_lower == value_upper:
+                LOGGER.info((
+                    "Transaction (id=%d) contains a receipt "
+                    "that has `%s` and `%s` keys with the same "
+                    "value. Removing the `%s` key."),
+                            transaction_dict['id'],
+                            field_name,
+                            field_name_upper,
+                            field_name_upper)
+                transaction_dict['receipt'].pop(field_name_upper)
+            else:
+                raise ValueError((
+                    "Found Transaction (id={}) with a receipt that has "
+                    "`{}` and `{}` keys with the different "
+                    "values. Contact Shopify/PayPal support.").format(
                         transaction_dict['id'],
-                        field_name,
                         field_name_upper,
-                        field_name_upper)
-            transaction_dict['receipt'].pop(field_name_upper)
-        else:
-            raise ValueError((
-                "Found Transaction (id={}) with a receipt that has "
-                "`{}` and `{}` keys with the different "
-                "values. Contact Shopify/PayPal support.").format(
-                    transaction_dict['id'],
-                    field_name_upper,
-                    field_name))
-    elif value_upper:
-        transaction_dict["receipt"][field_name] = transaction_dict['receipt'].pop(field_name_upper)
+                        field_name))
+        elif value_upper:
+            # pylint: disable=line-too-long
+            transaction_dict["receipt"][field_name] = transaction_dict['receipt'].pop(field_name_upper)
 
 
 class Transactions(Stream):

--- a/tap_shopify/streams/transactions.py
+++ b/tap_shopify/streams/transactions.py
@@ -105,7 +105,7 @@ class Transactions(Stream):
             transaction_dict = transaction.to_dict()
             replication_value = strptime_to_utc(transaction_dict[self.replication_key])
             if replication_value >= bookmark:
-                for field_name in ['token', 'version', 'ack']:
+                for field_name in ['token', 'version', 'ack', 'timestamp']:
                     canonicalize(transaction_dict, field_name)
                 yield transaction_dict
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -108,6 +108,16 @@ class BaseTapTest(unittest.TestCase):
                 self.PRIMARY_KEYS: {"id"},
                 self.FOREIGN_KEYS: {"order_id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.API_LIMIT: self.DEFAULT_RESULTS_PER_PAGE},
+            "locations": {
+                self.REPLICATION_KEYS: {"updated_at"},
+                self.PRIMARY_KEYS: {"id"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.API_LIMIT: 0},
+            "inventory_levels": {
+                self.REPLICATION_KEYS: {"updated_at"},
+                self.PRIMARY_KEYS: {"location_id", "inventory_item_id"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.API_LIMIT: self.DEFAULT_RESULTS_PER_PAGE}
         }
 
@@ -281,5 +291,5 @@ class BaseTapTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.start_date = self.get_properties().get("start_date")
-        self.store_1_streams = {'custom_collections', 'orders', 'products', 'customers','inventory_items'}
-        self.store_2_streams = {'abandoned_checkouts', 'collects', 'metafields', 'transactions', 'order_refunds', 'products','inventory_items'}
+        self.store_1_streams = {'custom_collections', 'orders', 'products', 'customers', 'locations', 'inventory_levels', 'inventory_items'}
+        self.store_2_streams = {'abandoned_checkouts', 'collects', 'metafields', 'transactions', 'order_refunds', 'products', 'locations', 'inventory_levels', 'inventory_items'}

--- a/tests/base.py
+++ b/tests/base.py
@@ -118,7 +118,13 @@ class BaseTapTest(unittest.TestCase):
                 self.REPLICATION_KEYS: {"updated_at"},
                 self.PRIMARY_KEYS: {"location_id", "inventory_item_id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.API_LIMIT: self.DEFAULT_RESULTS_PER_PAGE}
+                self.API_LIMIT: self.DEFAULT_RESULTS_PER_PAGE},
+            "events": {
+                self.REPLICATION_KEYS: {"created_at"},
+                self.PRIMARY_KEYS: {"id"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.API_LIMIT: 50
+            }
         }
 
     def expected_streams(self):
@@ -291,5 +297,5 @@ class BaseTapTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.start_date = self.get_properties().get("start_date")
-        self.store_1_streams = {'custom_collections', 'orders', 'products', 'customers', 'locations', 'inventory_levels', 'inventory_items'}
-        self.store_2_streams = {'abandoned_checkouts', 'collects', 'metafields', 'transactions', 'order_refunds', 'products', 'locations', 'inventory_levels', 'inventory_items'}
+        self.store_1_streams = {'custom_collections', 'orders', 'products', 'customers', 'locations', 'inventory_levels', 'inventory_items', 'events'}
+        self.store_2_streams = {'abandoned_checkouts', 'collects', 'metafields', 'transactions', 'order_refunds', 'products', 'locations', 'inventory_levels', 'inventory_items', 'events'}

--- a/tests/base.py
+++ b/tests/base.py
@@ -43,7 +43,7 @@ class BaseTapTest(unittest.TestCase):
             'shop': 'stitchdatawearhouse',
             'date_window_size': 30,
             # BUG: https://jira.talendforge.org/browse/TDL-13180
-            'results_per_page': '50'
+            # 'results_per_page': '50'
         }
 
         if original:

--- a/tests/base.py
+++ b/tests/base.py
@@ -98,6 +98,10 @@ class BaseTapTest(unittest.TestCase):
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.API_LIMIT: self.DEFAULT_RESULTS_PER_PAGE},
             "products": default,
+            "inventory_items": {self.REPLICATION_KEYS: {"updated_at"},
+                self.PRIMARY_KEYS: {"id"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.API_LIMIT: 250},
             "metafields": meta,
             "transactions": {
                 self.REPLICATION_KEYS: {"created_at"},
@@ -277,5 +281,5 @@ class BaseTapTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.start_date = self.get_properties().get("start_date")
-        self.store_1_streams = {'custom_collections', 'orders', 'products', 'customers'}
-        self.store_2_streams = {'abandoned_checkouts', 'collects', 'metafields', 'transactions', 'order_refunds', 'products'}
+        self.store_1_streams = {'custom_collections', 'orders', 'products', 'customers','inventory_items'}
+        self.store_2_streams = {'abandoned_checkouts', 'collects', 'metafields', 'transactions', 'order_refunds', 'products','inventory_items'}

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -14,7 +14,20 @@ class MinimumSelectionTest(BaseTapTest):
     def name():
         return "tap_tester_shopify_no_fields_test"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.start_date = '2021-04-01T00:00:00Z'
+
     def test_run(self):
+        with self.subTest(store="store_1"):
+            conn_id = self.create_connection(original_credentials=True)
+            self.automatic_test(conn_id, self.store_1_streams)
+
+        with self.subTest(store="store_2"):
+            conn_id = self.create_connection(original_properties=False, original_credentials=False)
+            self.automatic_test(conn_id, self.store_2_streams)
+
+    def automatic_test(self, conn_id, testable_streams):
         """
         Verify that for each stream you can get multiple pages of data
         when no fields are selected and only the automatic fields are replicated.
@@ -24,19 +37,15 @@ class MinimumSelectionTest(BaseTapTest):
         fetch of data.  For instance if you have a limit of 250 records ensure
         that 251 (or more) records have been posted for that stream.
         """
-        conn_id = self.create_connection()
-
         incremental_streams = {key for key, value in self.expected_replication_method().items()
-                               if value == self.INCREMENTAL}
+                               if value == self.INCREMENTAL and key in testable_streams}
 
         # Select all streams and no fields within streams
         # IF THERE ARE NO AUTOMATIC FIELDS FOR A STREAM
         # WE WILL NEED TO UPDATE THE BELOW TO SELECT ONE
         found_catalogs = menagerie.get_catalogs(conn_id)
-        untested_streams = self.child_streams().union({'abandoned_checkouts', 'collects', 'metafields', 'transactions', 'order_refunds'})
         our_catalogs = [catalog for catalog in found_catalogs if
-                        catalog.get('tap_stream_id') in incremental_streams.difference(
-                            untested_streams)]
+                        catalog.get('tap_stream_id') in incremental_streams]
         self.select_all_streams_and_fields(conn_id, our_catalogs, select_all_fields=False)
 
         # Run a sync job using orchestrator
@@ -44,22 +53,26 @@ class MinimumSelectionTest(BaseTapTest):
 
         actual_fields_by_stream = runner.examine_target_output_for_fields()
 
-        for stream in self.expected_streams().difference(untested_streams):
+        for stream in incremental_streams:
             with self.subTest(stream=stream):
 
                 # verify that you get more than a page of data
                 # SKIP THIS ASSERTION FOR STREAMS WHERE YOU CANNOT GET
                 # MORE THAN 1 PAGE OF DATA IN THE TEST ACCOUNT
+                stream_metadata = self.expected_metadata().get(stream, {})
+                minimum_record_count = stream_metadata.get(
+                    self.API_LIMIT,
+                    self.get_properties().get('result_per_page', self.DEFAULT_RESULTS_PER_PAGE)
+                )
                 self.assertGreater(
                     record_count_by_stream.get(stream, -1),
-                    self.expected_metadata().get(stream, {}).get(self.API_LIMIT, 0),
+                    minimum_record_count,
                     msg="The number of records is not over the stream max limit")
 
                 # verify that only the automatic fields are sent to the target
                 self.assertEqual(
                     actual_fields_by_stream.get(stream, set()),
                     self.expected_primary_keys().get(stream, set()) |
-                    self.expected_replication_keys().get(stream, set()) |
-                    self.expected_foreign_keys().get(stream, set()),
+                    self.expected_replication_keys().get(stream, set()),
                     msg="The fields sent to the target are not the automatic fields"
                 )

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -15,7 +15,20 @@ class BookmarkTest(BaseTapTest):
     def name():
         return "tap_tester_shopify_bookmark_test"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.start_date = '2021-04-01T00:00:00Z'
+
     def test_run(self):
+        with self.subTest(store="store_1"):
+            conn_id = self.create_connection(original_credentials=True)
+            self.bookmarks_test(conn_id, self.store_1_streams)
+
+        with self.subTest(store="store_2"):
+            conn_id = self.create_connection(original_properties=False, original_credentials=False)
+            self.bookmarks_test(conn_id, self.store_2_streams)
+
+    def bookmarks_test(self, conn_id, testable_streams):
         """
         Verify that for each stream you can do a sync which records bookmarks.
         That the bookmark is the maximum value sent to the target for the replication key.
@@ -32,18 +45,15 @@ class BookmarkTest(BaseTapTest):
         For EACH stream that is incrementally replicated there are multiple rows of data with
             different values for the replication key
         """
-        conn_id = self.create_connection()
 
         # Select all streams and no fields within streams
         found_catalogs = menagerie.get_catalogs(conn_id)
         incremental_streams = {key for key, value in self.expected_replication_method().items()
-                               if value == self.INCREMENTAL}
+                               if value == self.INCREMENTAL and key in testable_streams}
 
         # Our test data sets for Shopify do not have any abandoned_checkouts
-        untested_streams = self.child_streams().union({'abandoned_checkouts', 'collects', 'metafields', 'transactions', 'order_refunds'})
         our_catalogs = [catalog for catalog in found_catalogs if
-                        catalog.get('tap_stream_id') in incremental_streams.difference(
-                            untested_streams)]
+                        catalog.get('tap_stream_id') in incremental_streams]
         self.select_all_streams_and_fields(conn_id, our_catalogs, select_all_fields=False)
 
         # Run a sync job using orchestrator
@@ -51,7 +61,7 @@ class BookmarkTest(BaseTapTest):
 
         # verify that the sync only sent records to the target for selected streams (catalogs)
         self.assertEqual(set(first_sync_record_count.keys()),
-                         incremental_streams.difference(untested_streams))
+                         incremental_streams)
 
         first_sync_state = menagerie.get_state(conn_id)
 
@@ -69,7 +79,7 @@ class BookmarkTest(BaseTapTest):
 
         # THIS MAKES AN ASSUMPTION THAT CHILD STREAMS DO NOT HAVE BOOKMARKS.
         # ADJUST IF NECESSARY
-        for stream in incremental_streams.difference(untested_streams):
+        for stream in incremental_streams:
             with self.subTest(stream=stream):
 
                 # get bookmark values from state and target data

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -69,6 +69,19 @@ class BookmarkTest(BaseTapTest):
         first_sync_records = runner.get_records_from_target_output()
         first_max_bookmarks = self.max_bookmarks_by_stream(first_sync_records)
         first_min_bookmarks = self.min_bookmarks_by_stream(first_sync_records)
+        #first_sync_bookmarks = menagerie.get_state(conn_id)
+        
+        #######################
+        # Update State between Syncs
+        #######################
+
+        # new_state = {'bookmarks': dict()}
+        # simulated_states = self.calculated_states_by_stream(first_sync_bookmarks)
+
+        # for stream, updated_state in simulated_states.items():
+        #     new_state['bookmarks'][stream] = updated_state
+        # menagerie.set_state(conn_id, new_state)
+
 
         # Run a second sync job using orchestrator
         second_sync_record_count = self.run_sync(conn_id)

--- a/tests/test_bookmarks_updated.py
+++ b/tests/test_bookmarks_updated.py
@@ -1,0 +1,141 @@
+"""
+Test tap sets a bookmark and respects it for the next sync of a stream
+"""
+from datetime import datetime as dt
+
+from dateutil.parser import parse
+
+from tap_tester import menagerie, connections, runner
+from base import BaseTapTest
+
+
+class BookmarkTest(BaseTapTest):
+    """Test tap sets a bookmark and respects it for the next sync of a stream"""
+    @staticmethod
+    def name():
+        return "tap_tester_shopify_bookmark_test"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.start_date = '2021-04-01T00:00:00Z'
+    # We are currently working with 1 store as we do not have access to stitchdatawarehouse store
+    # def test_run_store_1(self):
+    #     with self.subTest(store="store_1"):
+    #         conn_id = self.create_connection(original_credentials=True)
+    #         self.bookmarks_test(conn_id, self.store_1_streams)
+
+    # creating this global variable for store 2 which is required only for this test, all the other test are referencing from base
+    global store_2_streams
+    store_2_streams = {'abandoned_checkouts', 'collects', 'metafields', 'transactions', 'order_refunds', 'products', 'locations', 'inventory_items', 'events', 'customers', 'custom_collections', 'orders'}
+
+    def test_run_store_2(self):
+        with self.subTest(store="store_2"):
+            conn_id = self.create_connection(original_properties=False, original_credentials=False)
+            self.bookmarks_test(conn_id, store_2_streams)
+
+    def bookmarks_test(self, conn_id, testable_streams):
+
+        # Select all streams and no fields within streams
+        found_catalogs = menagerie.get_catalogs(conn_id)
+        incremental_streams = {key for key, value in self.expected_replication_method().items()
+                               if value == self.INCREMENTAL and key in testable_streams}
+
+        # Our test data sets for Shopify do not have any abandoned_checkouts
+        our_catalogs = [catalog for catalog in found_catalogs if
+                        catalog.get('tap_stream_id') in incremental_streams]
+        self.select_all_streams_and_fields(conn_id, our_catalogs, select_all_fields=False)
+
+        #################################
+        # Run first sync
+        #################################
+
+        first_sync_record_count = self.run_sync(conn_id)
+
+        # verify that the sync only sent records to the target for selected streams (catalogs)
+        self.assertEqual(set(first_sync_record_count.keys()),
+                         incremental_streams)
+
+        first_sync_bookmark = menagerie.get_state(conn_id)
+        first_sync_records = runner.get_records_from_target_output()
+        # BUG:TDL-17087 : State has additional values which are not streams
+        # Need to remove additional values from bookmark value
+        extra_stuff = {'transaction_orders', 'metafield_products', 'refund_orders', 'product_variants'}
+        for keys in list(first_sync_bookmark['bookmarks'].keys()):
+            if keys in extra_stuff:
+                first_sync_bookmark['bookmarks'].pop(keys)
+
+        #######################
+        # Update State between Syncs
+        #######################
+
+        new_state = {'bookmarks': dict()}
+       #simulated_states = self.calculated_states_by_stream(first_sync_bookmark)
+
+        # We are hardcoding the updated state to ensure that we get atleast 1 record in second sync. These values have been provided after reviewing the max bookmark value for each of the streams
+        simulated_states = {'products': {'updated_at': '2021-12-20T05:10:05.000000Z'}, 'collects': {'updated_at': '2021-09-01T09:08:28.000000Z'}, 'abandoned_checkouts': {'updated_at': '2021-10-28T12:43:14.000000Z'}, 'inventory_levels': {'updated_at': '2021-12-20T05:09:34.000000Z'}, 'locations': {'updated_at': '2021-07-20T09:00:22.000000Z'}, 'events': {'created_at': '2021-12-20T05:09:01.000000Z'}, 'inventory_items': {'updated_at': '2021-09-15T19:44:11.000000Z'}, 'transactions': {'created_at': '2021-12-20T00:08:52-05:00'}, 'metafields': {'updated_at': '2021-09-07T21:18:05.000000Z'}, 'order_refunds': {'created_at': '2021-05-01T17:41:18.000000Z'}, 'customers': {'updated_at': '2021-12-20T05:08:17.000000Z'}, 'orders': {'updated_at': '2021-12-20T05:09:01.000000Z'}, 'custom_collections': {'updated_at': '2021-12-20T17:41:18.000000Z'}}
+
+        for stream, updated_state in simulated_states.items():
+            new_state['bookmarks'][stream] = updated_state
+        menagerie.set_state(conn_id, new_state)
+
+        ###############################
+        # Run Second Sync
+        ###############################
+
+        second_sync_record_count = self.run_sync(conn_id)
+        second_sync_records = runner.get_records_from_target_output()
+        second_sync_bookmark = menagerie.get_state(conn_id)
+
+        for stream in testable_streams:
+            with self.subTest(stream=stream):
+
+                # expected values
+                expected_replication_method = self.expected_replication_method()
+                expected_replication_keys = self.expected_replication_keys()
+                # information required for assertions from sync 1 and 2 based on expected values
+                first_sync_count = first_sync_record_count.get(stream, 0)
+                second_sync_count = second_sync_record_count.get(stream, 0)
+                first_sync_messages = [record.get('data') for record in first_sync_records.get(stream, {}).get('messages', [])
+                                       if record.get('action') == 'upsert']
+                second_sync_messages = [record.get('data') for record in second_sync_records.get(stream, {}).get('messages', [])
+                                        if record.get('action') == 'upsert']
+                first_bookmark_value = first_sync_bookmark.get('bookmarks', {stream: None}).get(stream)
+                first_bookmark_value = list(first_bookmark_value.values())[0]
+                second_bookmark_value = second_sync_bookmark.get('bookmarks', {stream: None}).get(stream)
+                second_bookmark_value = list(second_bookmark_value.values())[0]
+
+                replication_key = next(iter(expected_replication_keys[stream]))
+                first_bookmark_value_utc = self.convert_state_to_utc(first_bookmark_value)
+                second_bookmark_value_utc = self.convert_state_to_utc(second_bookmark_value)
+                simulated_bookmark = new_state['bookmarks'][stream]
+                simulated_bookmark_value = list(simulated_bookmark.values())[0]
+
+                # verify the syncs sets a bookmark of the expected form
+                self.assertIsNotNone(first_bookmark_value)
+                self.assertIsNotNone(second_bookmark_value)
+
+                # verify the 2nd bookmark is equal to 1st sync bookmark
+                #NOT A BUG (IS the expected behaviour for shopify as they are using date windowing : TDL-17096 : 2nd bookmark value is getting assigned from the execution time rather than the actual bookmark time. This is an invalid assertion for shopify
+                #self.assertEqual(first_bookmark_value, second_bookmark_value)
+
+                for record in first_sync_messages:
+                    replication_key_value = record.get(replication_key)
+                    # verify 1st sync bookmark value is the max replication key value for a given stream
+                    self.assertLessEqual(replication_key_value, first_bookmark_value_utc, msg="First sync bookmark was set incorrectly, a record with a greater replication key value was synced")
+
+                for record in second_sync_messages:
+                    replication_key_value = record.get(replication_key)
+                    # verify the 2nd sync replication key value is greater or equal to the 1st sync bookmarks
+                    self.assertGreaterEqual(replication_key_value, simulated_bookmark_value, msg="Second sync records do not respect the previous                                                  bookmark")
+                    # verify the 2nd sync bookmark value is the max replication key value for a given stream
+                    self.assertLessEqual(replication_key_value, second_bookmark_value_utc, msg="Second sync bookmark was set incorrectly, a record with a greater replication key value was synced")
+
+                # verify that we get less data in the 2nd sync
+                # collects has all the records with the same value of replication key, so we are removing from this assertion
+                if stream not in ('collects'):
+                    self.assertLess(second_sync_count, first_sync_count,
+                                    msg="Second sync does not have less records, bookmark usage not verified")
+
+                # verify that we get atleast 1 record in the second sync
+                if stream not in ('collects'):
+                    self.assertGreater(second_sync_count, 0, msg="Second sync did not yield any records")

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -22,9 +22,15 @@ class PaginationTest(BaseTapTest):
         return props
 
     def test_run(self):
-        # As it can call for max 100 product_variants and 
-        # we can generate only one inventory_item for one product_variants
-        excepted_streams = {'inventory_items'} 
+        # 'locations':
+        #       skip 'locations' stream as there is not much info about
+        #       limit of records returned in 1 page
+        #       Documentation: https://help.shopify.com/en/manual/locations/setting-up-your-locations
+        # 'inventory_items':
+        #       As it can call for max 100 product_variants and   
+        #       we can generate only one inventory_item for one product_variants
+        excepted_streams = {'locations', 'inventory_items'}
+
         with self.subTest(store="store_1"):
             conn_id = self.create_connection(original_credentials=True)
             self.pagination_test(conn_id, self.store_1_streams - excepted_streams)
@@ -62,6 +68,7 @@ class PaginationTest(BaseTapTest):
         # Run a sync job using orchestrator
         record_count_by_stream = self.run_sync(conn_id)
         actual_fields_by_stream = runner.examine_target_output_for_fields()
+        sync_records = runner.get_records_from_target_output()
 
         api_limit = int(self.get_properties().get('results_per_page', self.DEFAULT_RESULTS_PER_PAGE))
 
@@ -76,10 +83,13 @@ class PaginationTest(BaseTapTest):
                     minimum_record_count,
                     msg="The number of records is not over the stream max limit")
 
+                expected_pk = self.expected_primary_keys()
+                sync_messages = sync_records.get(stream, {'messages': []}).get('messages')
+
                 # verify that the automatic fields are sent to the target
                 self.assertTrue(
                     actual_fields_by_stream.get(stream, set()).issuperset(
-                        self.expected_primary_keys().get(stream, set()) |
+                        expected_pk.get(stream, set()) |
                         self.expected_replication_keys().get(stream, set()) |
                         self.expected_foreign_keys().get(stream, set())),
                     msg="The fields sent to the target don't include all automatic fields"
@@ -89,8 +99,18 @@ class PaginationTest(BaseTapTest):
                 # SKIP THIS ASSERTION IF ALL FIELDS ARE INTENTIONALLY AUTOMATIC FOR THIS STREAM
                 self.assertTrue(
                     actual_fields_by_stream.get(stream, set()).symmetric_difference(
-                        self.expected_primary_keys().get(stream, set()) |
+                        expected_pk.get(stream, set()) |
                         self.expected_replication_keys().get(stream, set()) |
                         self.expected_foreign_keys().get(stream, set())),
                     msg="The fields sent to the target don't include non-automatic fields"
                 )
+
+                # Verify we did not duplicate any records across pages
+                records_pks_set = {tuple([message.get('data').get(primary_key)
+                                          for primary_key in expected_pk.get(stream, set())])
+                                   for message in sync_messages}
+                records_pks_list = [tuple([message.get('data').get(primary_key)
+                                           for primary_key in expected_pk.get(stream, set())])
+                                    for message in sync_messages]
+                self.assertCountEqual(records_pks_set, records_pks_list,
+                                      msg=f"We have duplicate records for {stream}")

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -22,13 +22,16 @@ class PaginationTest(BaseTapTest):
         return props
 
     def test_run(self):
+        # As it can call for max 100 product_variants and 
+        # we can generate only one inventory_item for one product_variants
+        excepted_streams = {'inventory_items'} 
         with self.subTest(store="store_1"):
             conn_id = self.create_connection(original_credentials=True)
-            self.pagination_test(conn_id, self.store_1_streams)
+            self.pagination_test(conn_id, self.store_1_streams - excepted_streams)
 
         with self.subTest(store="store_2"):
             conn_id = self.create_connection(original_properties=False, original_credentials=False)
-            self.pagination_test(conn_id, self.store_2_streams)
+            self.pagination_test(conn_id, self.store_2_streams - excepted_streams)
 
     
     def pagination_test(self, conn_id, testable_streams):

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -16,6 +16,10 @@ class PaginationTest(BaseTapTest):
     def name(self):
         return "tap_tester_shopify_pagination_test"
 
+    def get_properties(self, *args, **kwargs):
+        props = super().get_properties(*args, **kwargs)
+        props['results_per_page'] = '50'
+        return props
 
     def test_run(self):
         with self.subTest(store="store_1"):
@@ -56,15 +60,14 @@ class PaginationTest(BaseTapTest):
         record_count_by_stream = self.run_sync(conn_id)
         actual_fields_by_stream = runner.examine_target_output_for_fields()
 
+        api_limit = int(self.get_properties().get('results_per_page', self.DEFAULT_RESULTS_PER_PAGE))
+
         for stream in testable_streams:
             with self.subTest(stream=stream):
 
                 # verify that we can paginate with all fields selected
                 stream_metadata = self.expected_metadata().get(stream, {})
-                minimum_record_count = stream_metadata.get(
-                    self.API_LIMIT,
-                    self.get_properties().get('result_per_page', self.DEFAULT_RESULTS_PER_PAGE)
-                )
+                minimum_record_count = 100 if stream == 'transactions' else api_limit
                 self.assertGreater(
                     record_count_by_stream.get(stream, -1),
                     minimum_record_count,

--- a/tests/test_shop_info_fields.py
+++ b/tests/test_shop_info_fields.py
@@ -1,0 +1,60 @@
+"""
+Test tap discovery
+"""
+import re
+
+from tap_tester import menagerie, runner
+
+from base import BaseTapTest
+
+
+class ShopInfoFieldsTest(BaseTapTest):
+    """ Test the Shop Information Fields """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.start_date = '2021-04-01T00:00:00Z'
+
+    @staticmethod
+    def name():
+        return "tap_tester_shopify_shop_info_fields_test"
+
+    def test_run(self):
+        """
+            Verify shop information fields are present in catalog for every streams.
+            Verify shop information fields are present in every records of all streams.
+        """
+        conn_id = self.create_connection(original_properties=False, original_credentials=False)
+        # Select all streams and all fields within streams and run both mode
+        found_catalogs = menagerie.get_catalogs(conn_id)
+
+        our_catalogs = [catalog for catalog in found_catalogs if
+                        catalog.get('tap_stream_id') in self.expected_streams()]
+
+        self.select_all_streams_and_fields(conn_id, our_catalogs, select_all_fields=True)
+        sync_records_count = self.run_sync(conn_id)
+        sync_records = runner.get_records_from_target_output()
+
+        expected_shop_info_fields = {'_sdc_shop_id', '_sdc_shop_name', '_sdc_shop_myshopify_domain'}
+
+        for stream in self.expected_streams():
+            with self.subTest(stream=stream):
+                
+                # Verify that every stream schema contains shop info fields
+                catalog = next(iter([catalog for catalog in found_catalogs
+                                     if catalog["stream_name"] == stream]))
+                schema_and_metadata = menagerie.get_annotated_schema(conn_id, catalog['stream_id'])
+                metadata = schema_and_metadata["metadata"]
+                actual_stream_fields = {item.get("breadcrumb", ["properties", None])[1]
+                                        for item in metadata
+                                        if item.get("breadcrumb", []) != []}
+
+                self.assertTrue(expected_shop_info_fields.issubset(actual_stream_fields))
+
+                # Verify that every records of stream contains shop info fields
+                stream_records = sync_records.get(stream, {})
+                upsert_messages = [m for m in stream_records.get('messages') if m['action'] == 'upsert']
+
+                for message in upsert_messages:
+                    actual_record_fields = set(message['data'].keys())
+                    self.assertTrue(expected_shop_info_fields.issubset(actual_record_fields))

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -4,6 +4,8 @@ Test that the start_date configuration is respected
 
 from functools import reduce
 
+import os
+
 from dateutil.parser import parse
 
 from tap_tester import menagerie, runner
@@ -23,6 +25,27 @@ class StartDateTest(BaseTapTest):
       is greater than or equal to the start date
     """
 
+    def get_properties(self, original: bool = True):
+        return_value = {
+            'start_date': '2021-04-01T00:00:00Z',
+            'shop': 'talenddatawearhouse',
+            'date_window_size': 30,
+            # BUG: https://jira.talendforge.org/browse/TDL-13180
+            'results_per_page': '50'
+        }
+
+        if original:
+            return return_value
+
+        return_value["start_date"] = '2021-04-21T00:00:00Z'
+        return return_value
+
+    @staticmethod
+    def get_credentials(original_credentials: bool = True):
+        return {
+            'api_key': os.getenv('TAP_SHOPIFY_API_KEY_TALENDDATAWEARHOUSE')
+        }
+
     @staticmethod
     def name():
         return "tap_tester_shopify_start_date_test"
@@ -38,10 +61,9 @@ class StartDateTest(BaseTapTest):
 
         # IF THERE ARE STREAMS THAT SHOULD NOT BE TESTED
         # REPLACE THE EMPTY SET BELOW WITH THOSE STREAMS
-        untested_streams = self.child_streams().union({'abandoned_checkouts', 'collects', 'metafields', 'transactions', 'order_refunds'})
+
         our_catalogs = [catalog for catalog in found_catalogs if
-                        catalog.get('tap_stream_id') in incremental_streams.difference(
-                            untested_streams)]
+                        catalog.get('tap_stream_id') in incremental_streams]
         self.select_all_streams_and_fields(conn_id, our_catalogs, select_all_fields=True)
 
         # Run a sync job using orchestrator
@@ -77,8 +99,7 @@ class StartDateTest(BaseTapTest):
         # Select all streams and all fields within streams
         found_catalogs = menagerie.get_catalogs(conn_id)
         our_catalogs = [catalog for catalog in found_catalogs if
-                        catalog.get('tap_stream_id') in incremental_streams.difference(
-                            untested_streams)]
+                        catalog.get('tap_stream_id') in incremental_streams]
         self.select_all_streams_and_fields(conn_id, our_catalogs, select_all_fields=True)
 
         # Run a sync job using orchestrator
@@ -91,7 +112,7 @@ class StartDateTest(BaseTapTest):
         self.assertGreater(second_total_records, 0)
         self.assertLess(second_total_records, first_total_records)
 
-        for stream in incremental_streams.difference(untested_streams):
+        for stream in incremental_streams:
             with self.subTest(stream=stream):
 
                 # verify that each stream has less records than the first connection sync

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -88,10 +88,7 @@ class StartDateTest(BaseTapTest):
             # REMOVE CODE TO FIND A START DATE AND ENTER ONE MANUALLY
             raise ValueError
 
-        largest_bookmark = reduce(lambda a, b: a if a > b else b, bookmark_dates)
-        self.start_date = self.local_to_utc(largest_bookmark) \
-                              .replace(hour=0, minute=0, second=0) \
-                              .strftime(self.START_DATE_FORMAT)
+        self.start_date = self.get_properties(original=False)["start_date"]
 
         # create a new connection with the new start_date
         conn_id = self.create_connection(original_properties=False)

--- a/tests/unittests/test_inventory_items.py
+++ b/tests/unittests/test_inventory_items.py
@@ -1,0 +1,92 @@
+import unittest
+from unittest import mock
+from singer.utils import strptime_to_utc
+from tap_shopify.context import Context
+
+INVENTORY_ITEM_OBJECT = Context.stream_objects['inventory_items']()
+
+class Product():
+    def __init__(self, id, variants):
+        self.id = id
+        self.variants = variants
+        
+class ProductVariant():
+    def __init__(self, id, inventory_item_id):
+        self.id = id
+        self.inventory_item_id = inventory_item_id
+
+class InventoryItems():
+    def __init__(self, id, updated_at):
+        self.id = id
+        self.updated_at = updated_at
+        
+    def to_dict(self):
+        return {"id": self.id, "updated_at": self.updated_at}
+
+ITEM_1 = InventoryItems("i11", "2021-08-11T01:57:05-04:00")
+ITEM_2 = InventoryItems("i12", "2021-08-12T01:57:05-04:00")
+ITEM_3 = InventoryItems("i21", "2021-08-13T01:57:05-04:00")
+ITEM_4 = InventoryItems("i22", "2021-08-14T01:57:05-04:00")
+        
+class TestInventoryItems(unittest.TestCase):
+
+    @mock.patch("tap_shopify.streams.base.Stream.get_objects")
+    @mock.patch("tap_shopify.streams.inventory_items.InventoryItems.get_inventory_items")
+    def test_get_objects_with_product_variant(self, mock_get_inventory_items, mock_parent_object):
+
+        expected_inventory_items =  [ITEM_1, ITEM_2, ITEM_3, ITEM_4]
+        product1 = Product("p1", [ProductVariant("v11", "i11"), ProductVariant("v21", "i21")])
+        product2 = Product("p2", [ProductVariant("v12", "i12"), ProductVariant("v22", "i22")])
+        
+        mock_get_inventory_items.side_effect = [[ITEM_1, ITEM_2], [ITEM_3, ITEM_4]]
+        mock_parent_object.return_value = [product1, product2]
+
+        actual_inventory_items = list(INVENTORY_ITEM_OBJECT.get_objects())
+        
+        #Verify that it returns inventory_item of all product variant
+        self.assertEqual(actual_inventory_items, expected_inventory_items)
+        
+    
+    @mock.patch("tap_shopify.streams.base.Stream.get_objects")
+    @mock.patch("tap_shopify.streams.inventory_items.InventoryItems.get_inventory_items")
+    def test_get_objects_with_product_but_no_variant(self, mock_get_inventory_items, mock_parent_object):
+                
+        expected_inventory_items =  [ITEM_3, ITEM_4]
+        
+        #Product1 contain no variant
+        product1 = Product("p1", [])
+        
+        product2 = Product("p2", [ProductVariant("v12", "i12"), ProductVariant("v22", "i22")])
+        mock_parent_object.return_value = [product1, product2]
+        
+        mock_get_inventory_items.side_effect = [[], [ITEM_3, ITEM_4]] 
+        
+        actual_inventory_items = list(INVENTORY_ITEM_OBJECT.get_objects())
+        #Verify that it returns inventory_item of existing product variant
+        self.assertEqual(actual_inventory_items, expected_inventory_items)
+    
+    
+    @mock.patch("tap_shopify.streams.base.Stream.get_objects")
+    @mock.patch("tap_shopify.streams.inventory_items.InventoryItems.get_inventory_items")
+    def test_get_objects_with_no_product(self, mock_get_inventory_items, mock_parent_object):
+        
+        #No product exist
+        mock_parent_object.return_value = []
+        expected_inventory_items = []
+        
+        actual_inventory_items = list(INVENTORY_ITEM_OBJECT.get_objects())
+        self.assertEqual(actual_inventory_items, expected_inventory_items)
+        
+    @mock.patch("tap_shopify.streams.base.Stream.get_bookmark")
+    @mock.patch("tap_shopify.streams.inventory_items.InventoryItems.get_objects")
+    def test_sync(self, mock_get_objects, mock_get_bookmark):
+                
+        expected_sync = [ITEM_3.to_dict(), ITEM_4.to_dict()]
+        mock_get_objects.return_value = [ITEM_1, ITEM_2, ITEM_3, ITEM_4]
+        
+        mock_get_bookmark.return_value = strptime_to_utc("2021-08-13T01:05:05-04:00")
+        
+        actual_sync = list(INVENTORY_ITEM_OBJECT.sync())
+        
+        #Verify that only 2 record syncs
+        self.assertEqual(actual_sync, expected_sync)

--- a/tests/unittests/test_inventory_levels.py
+++ b/tests/unittests/test_inventory_levels.py
@@ -1,0 +1,76 @@
+import unittest
+from unittest import mock
+from singer.utils import strptime_to_utc
+from tap_shopify.context import Context
+
+INVENTORY_LEVEL_OBJECT = Context.stream_objects['inventory_levels']()
+
+class Location():
+    def __init__(self, id):
+        self.id = id
+
+class InventoryLevels():
+    def __init__(self, id, updated_at):
+        self.id = id
+        self.updated_at = updated_at
+
+    def to_dict(self):
+        return {"id": self.id, "updated_at": self.updated_at}
+
+LEVEL_1 = InventoryLevels("inv_level1", "2021-08-11T01:57:05-04:00")
+LEVEL_2 = InventoryLevels("inv_level2", "2021-08-12T01:57:05-04:00")
+LEVEL_3 = InventoryLevels("inv_level3", "2021-08-13T01:57:05-04:00")
+LEVEL_4 = InventoryLevels("inv_level4", "2021-08-14T01:57:05-04:00")
+
+@mock.patch("tap_shopify.streams.base.Stream.get_bookmark")
+class TestInventoryItems(unittest.TestCase):
+
+    @mock.patch("tap_shopify.streams.locations.Locations.get_locations_data")
+    @mock.patch("tap_shopify.streams.inventory_levels.InventoryLevels.get_inventory_levels")
+    def test_get_objects_with_locations(self, mock_get_inventory_levels, mock_parent_object, mock_get_bookmark):
+        '''
+            Verify that expected data should be emitted for inventory_levels if locations found.
+        '''
+        expected_inventory_levels =  [LEVEL_1, LEVEL_2, LEVEL_3, LEVEL_4]
+        location1 = Location("location1")
+        location2 = Location("location2")
+
+        mock_get_inventory_levels.side_effect = [[LEVEL_1, LEVEL_2], [LEVEL_3, LEVEL_4]]
+        mock_parent_object.return_value = [location1, location2]
+
+        actual_inventory_levels = list(INVENTORY_LEVEL_OBJECT.get_objects())
+
+        #Verify that it returns inventory_levels for all locations
+        self.assertEqual(actual_inventory_levels, expected_inventory_levels)
+
+    @mock.patch("tap_shopify.streams.locations.Locations.get_locations_data")
+    @mock.patch("tap_shopify.streams.inventory_levels.InventoryLevels.get_inventory_levels")
+    def test_get_objects_with_no_locations(self, mock_get_inventory_levels, mock_parent_object, mock_get_bookmark):
+        '''
+            Verify that no data should be emitted for inventory_levels if no locations found.
+        '''
+        # No data for parent stream location
+        mock_parent_object.return_value = []
+        expected_inventory_levels = []
+
+        actual_inventory_levels = list(INVENTORY_LEVEL_OBJECT.get_objects())
+
+        # No get_inventory_levels should be called and no data should be returned 
+        self.assertEqual(actual_inventory_levels, expected_inventory_levels)
+        self.assertEqual(mock_get_inventory_levels.call_count, 0)
+
+    @mock.patch("tap_shopify.streams.inventory_levels.InventoryLevels.get_objects")
+    def test_sync(self, mock_get_objects, mock_get_bookmark):
+        '''
+            Verify that only data updated after specific bookmark are yielded from sync.
+        '''
+
+        expected_sync = [LEVEL_3.to_dict(), LEVEL_4.to_dict()]
+        mock_get_objects.return_value = [LEVEL_1, LEVEL_2, LEVEL_3, LEVEL_4]
+
+        mock_get_bookmark.return_value = strptime_to_utc("2021-08-13T01:05:05-04:00")
+
+        actual_sync = list(INVENTORY_LEVEL_OBJECT.sync())
+
+        #Verify that only 2 record syncs
+        self.assertEqual(actual_sync, expected_sync)

--- a/tests/unittests/test_locations.py
+++ b/tests/unittests/test_locations.py
@@ -1,0 +1,43 @@
+import unittest
+from unittest import mock
+from singer import utils
+from singer.utils import strptime_to_utc, strftime
+from tap_shopify.context import Context
+
+LOCATIONS_OBJECT = Context.stream_objects['locations']()
+
+
+class Locations():
+    def __init__(self, id, updated_at):
+        self.id = id
+        self.updated_at = updated_at
+
+    def to_dict(self):
+        return {"id": self.id, "updated_at": self.updated_at}
+
+
+LOCATION_1 = Locations("i11", "2021-08-11T01:57:05-04:00")
+LOCATION_2 = Locations("i12", "2021-08-12T01:57:05-04:00")
+LOCATION_3 = Locations("i21", "2021-08-13T01:57:05-04:00")
+LOCATION_4 = Locations("i22", "2021-08-14T01:57:05-04:00")
+
+
+class TestLocations(unittest.TestCase):
+    @mock.patch("tap_shopify.streams.base.Stream.update_bookmark")
+    @mock.patch("tap_shopify.streams.base.Stream.get_bookmark")
+    @mock.patch("tap_shopify.streams.locations.Locations.get_locations_data")
+    def test_sync(self, mock_get_locations_data, mock_get_bookmark, mock_update_bookmark):
+
+        expected_sync = [LOCATION_3.to_dict(), LOCATION_4.to_dict()]
+        mock_get_locations_data.return_value = [LOCATION_1, LOCATION_2, LOCATION_3, LOCATION_4]
+
+        mock_get_bookmark.return_value = strptime_to_utc("2021-08-13T01:05:05-04:00")
+
+        actual_sync = list(LOCATIONS_OBJECT.sync())
+
+        # Verify that only 2 record syncs
+        self.assertEqual(actual_sync, expected_sync)
+        max_bookmark = strptime_to_utc("2021-08-14T01:57:05-04:00")
+
+        # Verify that maximum replication key of all keys is updated as bookmark
+        mock_update_bookmark.assert_called_with(utils.strftime(max_bookmark))

--- a/tests/unittests/test_shop_info.py
+++ b/tests/unittests/test_shop_info.py
@@ -1,0 +1,25 @@
+import tap_shopify
+import unittest
+
+class TestShopInfo(unittest.TestCase):
+
+    def test_shop_info_schema(self):
+        schema = {
+            'properties': {
+                'field_1': {
+                    'type': ['null', 'string']
+                },
+                'field_2': {
+                    'type': ['null', 'integer']
+                },
+                'field_3': {
+                    'type': ['null', 'string']
+                }
+            },
+            'type': 'object'
+        }
+        schema_with_shop_info = tap_shopify.add_synthetic_key_to_schema(schema)
+        actual_keys = schema_with_shop_info.get('properties').keys()
+        expected_keys = ['_sdc_shop_id', '_sdc_shop_name', '_sdc_shop_myshopify_domain']
+        for key in expected_keys:
+            self.assertTrue(key in actual_keys)

--- a/tests/unittests/test_timeout.py
+++ b/tests/unittests/test_timeout.py
@@ -1,0 +1,576 @@
+import socket
+import tap_shopify
+from unittest import mock
+import pyactiveresource
+import shopify
+from tap_shopify.context import Context
+from tap_shopify.streams.base import get_request_timeout
+from tap_shopify.streams.inventory_items import InventoryItems
+from tap_shopify.streams.inventory_levels import InventoryLevels
+from tap_shopify.streams.locations import Locations
+from tap_shopify.streams.order_refunds import OrderRefunds
+from tap_shopify.streams.transactions import Transactions
+from tap_shopify.streams.abandoned_checkouts import AbandonedCheckouts
+from tap_shopify.streams.metafields import Metafields
+from tap_shopify.streams.metafields import get_metafields
+import unittest
+
+class TestTimeoutValue(unittest.TestCase):
+    """
+        Verify the timeout value is set as expected by the tap
+    """
+
+    def test_timeout_value_not_passed_in_config(self):
+        """
+            Test case to verify that the default value is used when we do not pass request timeout value from config
+        """
+        # initialize config
+        Context.config = {
+            "start_date": "2021-01-01",
+            "api_key": "test_api_key",
+            "shop": "test_shop",
+            "results_per_page": 50
+        }
+
+        # initialize base class
+        timeout = get_request_timeout()
+        # verify the timeout is set as expected
+        self.assertEquals(timeout, 300)
+
+    def test_timeout_int_value_passed_in_config(self):
+        """
+            Test case to verify that the value we passed on config is set as request timeout value
+        """
+        # initialize config
+        Context.config = {
+            "start_date": "2021-01-01",
+            "api_key": "test_api_key",
+            "shop": "test_shop",
+            "results_per_page": 50,
+            "request_timeout": 100
+        }
+
+        # initialize base class
+        timeout = get_request_timeout()
+        # verify the timeout is set as expected
+        self.assertEquals(timeout, 100)
+
+    def test_timeout_string_value_passed_in_config(self):
+        """
+            Test case to verify that the value we passed on config is set as request timeout value
+        """
+        # initialize config
+        Context.config = {
+            "start_date": "2021-01-01",
+            "api_key": "test_api_key",
+            "shop": "test_shop",
+            "results_per_page": 50,
+            "request_timeout": "100"
+        }
+
+        # initialize base class
+        timeout = get_request_timeout()
+        # verify the timeout is set as expected
+        self.assertEquals(timeout, 100)
+
+    def test_timeout_empty_value_passed_in_config(self):
+        """
+            Test case to verify that the default value is used when pass empty request timeout value from config
+        """
+        # initialize config
+        Context.config = {
+            "start_date": "2021-01-01",
+            "api_key": "test_api_key",
+            "shop": "test_shop",
+            "results_per_page": 50,
+            "request_timeout": ""
+        }
+
+        # initialize base class
+        timeout = get_request_timeout()
+        # verify the timeout is set as expected
+        self.assertEquals(timeout, 300)
+
+    def test_timeout_0_value_passed_in_config(self):
+        """
+            Test case to verify that the default value is used when pass 0 as request timeout value from config
+        """
+        # initialize config
+        Context.config = {
+            "start_date": "2021-01-01",
+            "api_key": "test_api_key",
+            "shop": "test_shop",
+            "results_per_page": 50,
+            "request_timeout": 0.0
+        }
+
+        # initialize base class
+        timeout = get_request_timeout()
+        # verify the timeout is set as expected
+        self.assertEquals(timeout, 300)
+
+    def test_timeout_string_0_value_passed_in_config(self):
+        """
+            Test case to verify that the default value is used when pass string 0 as request timeout value from config
+        """
+        # initialize config
+        Context.config = {
+            "start_date": "2021-01-01",
+            "api_key": "test_api_key",
+            "shop": "test_shop",
+            "results_per_page": 50,
+            "request_timeout": "0.0"
+        }
+
+        # initialize base class
+        timeout = get_request_timeout()
+        # verify the timeout is set as expected
+        self.assertEquals(timeout, 300)
+
+    @mock.patch("shopify.Shop.set_timeout")
+    @mock.patch("shopify.Shop.current")
+    def test_timeout_value_not_passed_in_config__initialize_shopify_client(self, mocked_current, mocked_set_timeout):
+        """
+            Test case to verify that the default value is used when we do not pass request timeout value from config
+        """
+        # initialize config
+        Context.config = {
+            "start_date": "2021-01-01",
+            "api_key": "test_api_key",
+            "shop": "test_shop",
+            "results_per_page": 50
+        }
+
+        # function call
+        tap_shopify.initialize_shopify_client()
+        # verify the timeout is set as expected
+        mocked_set_timeout.assert_called_with(300)
+
+    @mock.patch("shopify.Shop.set_timeout")
+    @mock.patch("shopify.Shop.current")
+    def test_timeout_int_value_passed_in_config__initialize_shopify_client(self, mocked_current, mocked_set_timeout):
+        """
+            Test case to verify that the value we passed on config is set as request timeout value
+        """
+        # initialize config
+        Context.config = {
+            "start_date": "2021-01-01",
+            "api_key": "test_api_key",
+            "shop": "test_shop",
+            "results_per_page": 50,
+            "request_timeout": 100
+        }
+
+        # function call
+        tap_shopify.initialize_shopify_client()
+        # verify the timeout is set as expected
+        mocked_set_timeout.assert_called_with(100)
+
+    @mock.patch("shopify.Shop.set_timeout")
+    @mock.patch("shopify.Shop.current")
+    def test_timeout_string_value_passed_in_config__initialize_shopify_client(self, mocked_current, mocked_set_timeout):
+        """
+            Test case to verify that the value we passed on config is set as request timeout value
+        """
+        # initialize config
+        Context.config = {
+            "start_date": "2021-01-01",
+            "api_key": "test_api_key",
+            "shop": "test_shop",
+            "results_per_page": 50,
+            "request_timeout": "100"
+        }
+
+        # function call
+        tap_shopify.initialize_shopify_client()
+        # verify the timeout is set as expected
+        mocked_set_timeout.assert_called_with(100)
+
+    @mock.patch("shopify.Shop.set_timeout")
+    @mock.patch("shopify.Shop.current")
+    def test_timeout_empty_value_passed_in_config__initialize_shopify_client(self, mocked_current, mocked_set_timeout):
+        """
+            Test case to verify that the default value is used when pass empty request timeout value from config
+        """
+        # initialize config
+        Context.config = {
+            "start_date": "2021-01-01",
+            "api_key": "test_api_key",
+            "shop": "test_shop",
+            "results_per_page": 50,
+            "request_timeout": ""
+        }
+
+        # function call
+        tap_shopify.initialize_shopify_client()
+        # verify the timeout is set as expected
+        mocked_set_timeout.assert_called_with(300)
+
+    @mock.patch("shopify.Shop.set_timeout")
+    @mock.patch("shopify.Shop.current")
+    def test_timeout_0_value_passed_in_config__initialize_shopify_client(self, mocked_current, mocked_set_timeout):
+        """
+            Test case to verify that the default value is used when pass 0 as request timeout value from config
+        """
+        # initialize config
+        Context.config = {
+            "start_date": "2021-01-01",
+            "api_key": "test_api_key",
+            "shop": "test_shop",
+            "results_per_page": 50,
+            "request_timeout": 0.0
+        }
+
+        # function call
+        tap_shopify.initialize_shopify_client()
+        # verify the timeout is set as expected
+        mocked_set_timeout.assert_called_with(300)
+
+    @mock.patch("shopify.Shop.set_timeout")
+    @mock.patch("shopify.Shop.current")
+    def test_timeout_string_0_value_passed_in_config__initialize_shopify_client(self, mocked_current, mocked_set_timeout):
+        """
+            Test case to verify that the default value is used when pass string 0 as request timeout value from config
+        """
+        # initialize config
+        Context.config = {
+            "start_date": "2021-01-01",
+            "api_key": "test_api_key",
+            "shop": "test_shop",
+            "results_per_page": 50,
+            "request_timeout": "0.0"
+        }
+
+        # function call
+        tap_shopify.initialize_shopify_client()
+        # verify the timeout is set as expected
+        mocked_set_timeout.assert_called_with(300)
+
+class TestTimeoutBackoff(unittest.TestCase):
+    """
+        Verify the tap backoff for 5 times when timeout error occurs
+    """
+
+    @mock.patch("time.sleep")
+    @mock.patch("shopify.Checkout.find")
+    def test_AbandonedCheckouts_pyactiveresource_error_timeout_backoff(self, mocked_find, mocked_sleep):
+        """
+            Test case to verify that we backoff for 5 times when 'pyactiveresource.connection.Error' error occurs
+        """
+        # mock 'find' and raise timeout error
+        mocked_find.side_effect = pyactiveresource.connection.Error('urlopen error _ssl.c:1074: The handshake operation timed out')
+
+        # initialize 'AbandonedCheckouts' as it calls the function 'call_api' from the base class
+        abandoned_checkouts = AbandonedCheckouts()
+        try:
+            # function call
+            abandoned_checkouts.call_api({})
+        except pyactiveresource.connection.Error:
+            pass
+
+        # verify we backoff 5 times
+        self.assertEquals(mocked_find.call_count, 5)
+
+    @mock.patch("time.sleep")
+    @mock.patch("shopify.InventoryItem.find")
+    def test_InventoryItems_pyactiveresource_error_timeout_backoff(self, mocked_find, mocked_sleep):
+        """
+            Test case to verify that we backoff for 5 times when 'pyactiveresource.connection.Error' error occurs
+        """
+        # mock 'find' and raise timeout error
+        mocked_find.side_effect = pyactiveresource.connection.Error('urlopen error _ssl.c:1074: The handshake operation timed out')
+
+        # initialize class
+        inventory_items = InventoryItems()
+        try:
+            # function call
+            inventory_items.get_inventory_items([1, 2, 3])
+        except pyactiveresource.connection.Error:
+            pass
+
+        # verify we backoff 5 times
+        self.assertEquals(mocked_find.call_count, 5)
+
+    @mock.patch("time.sleep")
+    @mock.patch("pyactiveresource.activeresource.ActiveResource.find")
+    def test_InventoryLevels_pyactiveresource_error_timeout_backoff(self, mocked_find, mocked_sleep):
+        """
+            Test case to verify that we backoff for 5 times when 'pyactiveresource.connection.Error' error occurs
+        """
+        # mock 'find' and raise timeout error
+        mocked_find.side_effect = pyactiveresource.connection.Error('urlopen error _ssl.c:1074: The handshake operation timed out')
+
+        # initialize class
+        inventory_levels = InventoryLevels()
+        try:
+            # function call
+            inventory_levels.api_call_for_inventory_levels(1, 'test')
+        except pyactiveresource.connection.Error:
+            pass
+
+        # verify we backoff 5 times
+        self.assertEquals(mocked_find.call_count, 5)
+
+    @mock.patch("time.sleep")
+    @mock.patch("pyactiveresource.activeresource.ActiveResource.find")
+    def test_Locations_pyactiveresource_error_timeout_backoff(self, mocked_find, mocked_sleep):
+        """
+            Test case to verify that we backoff for 5 times when 'pyactiveresource.connection.Error' error occurs
+        """
+        # mock 'find' and raise timeout error
+        mocked_find.side_effect = pyactiveresource.connection.Error('urlopen error _ssl.c:1074: The handshake operation timed out')
+
+        # initialize class
+        locations = Locations()
+        try:
+            # function call
+            locations.replication_object.find()
+        except pyactiveresource.connection.Error:
+            pass
+
+        # verify we backoff 5 times
+        self.assertEquals(mocked_find.call_count, 5)
+
+    @mock.patch("time.sleep")
+    @mock.patch("shopify.Order.metafields")
+    def test_Metafields_pyactiveresource_error_timeout_backoff(self, mocked_find, mocked_sleep):
+        """
+            Test case to verify that we backoff for 5 times when 'pyactiveresource.connection.Error' error occurs
+        """
+        # mock 'find' and raise timeout error
+        mocked_find.side_effect = pyactiveresource.connection.Error('urlopen error _ssl.c:1074: The handshake operation timed out')
+
+        try:
+            # function call
+            get_metafields(shopify.Order, 1, shopify.Order, 100)
+        except pyactiveresource.connection.Error:
+            pass
+
+        # verify we backoff 5 times
+        self.assertEquals(mocked_find.call_count, 5)
+
+    @mock.patch("time.sleep")
+    @mock.patch("shopify.Refund.find")
+    def test_OrderRefunds_pyactiveresource_error_timeout_backoff(self, mocked_find, mocked_sleep):
+        """
+            Test case to verify that we backoff for 5 times when 'pyactiveresource.connection.Error' error occurs
+        """
+        # mock 'find' and raise timeout error
+        mocked_find.side_effect = pyactiveresource.connection.Error('urlopen error _ssl.c:1074: The handshake operation timed out')
+
+        # initialize class
+        order_refunds = OrderRefunds()
+        try:
+            # function call
+            order_refunds.get_refunds(shopify.Product, 1)
+        except pyactiveresource.connection.Error:
+            pass
+
+        # verify we backoff 5 times
+        self.assertEquals(mocked_find.call_count, 5)
+
+    @mock.patch("time.sleep")
+    @mock.patch("pyactiveresource.activeresource.ActiveResource.find")
+    def test_Transactions_pyactiveresource_error_timeout_backoff(self, mocked_find, mocked_sleep):
+        """
+            Test case to verify that we backoff for 5 times when 'pyactiveresource.connection.Error' error occurs
+        """
+        # mock 'find' and raise timeout error
+        mocked_find.side_effect = pyactiveresource.connection.Error('urlopen error _ssl.c:1074: The handshake operation timed out')
+
+        # initialize class
+        locations = Transactions()
+        try:
+            # function call
+            locations.replication_object.find()
+        except pyactiveresource.connection.Error:
+            pass
+
+        # verify we backoff 5 times
+        self.assertEquals(mocked_find.call_count, 5)
+
+    @mock.patch("time.sleep")
+    @mock.patch("shopify.Shop.current")
+    def test_Shop_pyactiveresource_error_timeout_backoff(self, mocked_current, mocked_sleep):
+        """
+            Test case to verify that we backoff for 5 times when 'pyactiveresource.connection.Error' error occurs
+        """
+        # mock 'Shop' call and raise timeout error
+        mocked_current.side_effect = pyactiveresource.connection.Error('urlopen error _ssl.c:1074: The handshake operation timed out')
+
+        Context.config = {
+            "api_key": "test_api_key",
+            "shop": "test_shop"
+        }
+        try:
+            # function call
+            tap_shopify.initialize_shopify_client()
+        except pyactiveresource.connection.Error:
+            pass
+
+        # verify we backoff 5 times
+        self.assertEquals(mocked_current.call_count, 5)
+
+    """
+        Verify the tap backoff for 5 times when timeout error occurs
+    """
+
+    @mock.patch("time.sleep")
+    @mock.patch("shopify.Checkout.find")
+    def test_AbandonedCheckouts_socket_timeout_backoff(self, mocked_find, mocked_sleep):
+        """
+            Test case to verify that we backoff for 5 times when 'socket.timeout' error occurs
+        """
+        # mock 'find' and raise timeout error
+        mocked_find.side_effect = socket.timeout("The read operation timed out")
+
+        # initialize 'AbandonedCheckouts' as it calls the function 'call_api' from the base class
+        abandoned_checkouts = AbandonedCheckouts()
+        try:
+            # function call
+            abandoned_checkouts.call_api({})
+        except socket.timeout:
+            pass
+
+        # verify we backoff 5 times
+        self.assertEquals(mocked_find.call_count, 5)
+
+    @mock.patch("time.sleep")
+    @mock.patch("shopify.InventoryItem.find")
+    def test_InventoryItems_socket_timeout_backoff(self, mocked_find, mocked_sleep):
+        """
+            Test case to verify that we backoff for 5 times when 'socket.timeout' error occurs
+        """
+        # mock 'find' and raise timeout error
+        mocked_find.side_effect = socket.timeout("The read operation timed out")
+
+        # initialize class
+        inventory_items = InventoryItems()
+        try:
+            # function call
+            inventory_items.get_inventory_items([1, 2, 3])
+        except socket.timeout:
+            pass
+
+        # verify we backoff 5 times
+        self.assertEquals(mocked_find.call_count, 5)
+
+    @mock.patch("time.sleep")
+    @mock.patch("pyactiveresource.activeresource.ActiveResource.find")
+    def test_InventoryLevels_socket_timeout_backoff(self, mocked_find, mocked_sleep):
+        """
+            Test case to verify that we backoff for 5 times when 'socket.timeout' error occurs
+        """
+        # mock 'find' and raise timeout error
+        mocked_find.side_effect = socket.timeout("The read operation timed out")
+
+        # initialize class
+        inventory_levels = InventoryLevels()
+        try:
+            # function call
+            inventory_levels.api_call_for_inventory_levels(1, 'test')
+        except socket.timeout:
+            pass
+
+        # verify we backoff 5 times
+        self.assertEquals(mocked_find.call_count, 5)
+
+    @mock.patch("time.sleep")
+    @mock.patch("pyactiveresource.activeresource.ActiveResource.find")
+    def test_Locations_socket_timeout_backoff(self, mocked_find, mocked_sleep):
+        """
+            Test case to verify that we backoff for 5 times when 'socket.timeout' error occurs
+        """
+        # mock 'find' and raise timeout error
+        mocked_find.side_effect = socket.timeout("The read operation timed out")
+
+        # initialize class
+        locations = Locations()
+        try:
+            # function call
+            locations.replication_object.find()
+        except socket.timeout:
+            pass
+
+        # verify we backoff 5 times
+        self.assertEquals(mocked_find.call_count, 5)
+
+    @mock.patch("time.sleep")
+    @mock.patch("shopify.Order.metafields")
+    def test_Metafields_socket_timeout_backoff(self, mocked_find, mocked_sleep):
+        """
+            Test case to verify that we backoff for 5 times when 'socket.timeout' error occurs
+        """
+        # mock 'find' and raise timeout error
+        mocked_find.side_effect = socket.timeout("The read operation timed out")
+
+        try:
+            # function call
+            get_metafields(shopify.Order, 1, shopify.Order, 100)
+        except socket.timeout:
+            pass
+
+        # verify we backoff 5 times
+        self.assertEquals(mocked_find.call_count, 5)
+
+    @mock.patch("time.sleep")
+    @mock.patch("shopify.Refund.find")
+    def test_OrderRefunds_socket_timeout_backoff(self, mocked_find, mocked_sleep):
+        """
+            Test case to verify that we backoff for 5 times when 'socket.timeout' error occurs
+        """
+        # mock 'find' and raise timeout error
+        mocked_find.side_effect = socket.timeout("The read operation timed out")
+
+        # initialize class
+        order_refunds = OrderRefunds()
+        try:
+            # function call
+            order_refunds.get_refunds(shopify.Product, 1)
+        except socket.timeout:
+            pass
+
+        # verify we backoff 5 times
+        self.assertEquals(mocked_find.call_count, 5)
+
+    @mock.patch("time.sleep")
+    @mock.patch("pyactiveresource.activeresource.ActiveResource.find")
+    def test_Transactions_socket_timeout_backoff(self, mocked_find, mocked_sleep):
+        """
+            Test case to verify that we backoff for 5 times when 'socket.timeout' error occurs
+        """
+        # mock 'find' and raise timeout error
+        mocked_find.side_effect = socket.timeout("The read operation timed out")
+
+        # initialize class
+        locations = Transactions()
+        try:
+            # function call
+            locations.replication_object.find()
+        except socket.timeout:
+            pass
+
+        # verify we backoff 5 times
+        self.assertEquals(mocked_find.call_count, 5)
+
+    @mock.patch("time.sleep")
+    @mock.patch("shopify.Shop.current")
+    def test_Shop_socket_timeout_backoff(self, mocked_current, mocked_sleep):
+        """
+            Test case to verify that we backoff for 5 times when 'socket.timeout' error occurs
+        """
+        # mock 'Shop' call and raise timeout error
+        mocked_current.side_effect = socket.timeout("The read operation timed out")
+
+        Context.config = {
+            "api_key": "test_api_key",
+            "shop": "test_shop"
+        }
+        try:
+            # function call
+            tap_shopify.initialize_shopify_client()
+        except socket.timeout:
+            pass
+
+        # verify we backoff 5 times
+        self.assertEquals(mocked_current.call_count, 5)

--- a/tests/unittests/test_token_check_in_discover.py
+++ b/tests/unittests/test_token_check_in_discover.py
@@ -1,0 +1,84 @@
+from unittest import mock
+
+import pyactiveresource
+import tap_shopify
+import unittest
+
+# Mock args
+class Args():
+    def __init__(self):
+        self.discover = True
+        self.catalog = False
+        self.config = {'api_key': 'test', 'shop': 'shop'}
+        self.state = False
+
+def resource_not_found_raiser():
+    raise pyactiveresource.connection.ResourceNotFound
+
+def unauthorized_access_raiser():
+    raise pyactiveresource.connection.UnauthorizedAccess
+
+def connection_error_raiser():
+    raise pyactiveresource.connection.ConnectionError
+
+@mock.patch('tap_shopify.utils.parse_args')
+@mock.patch('tap_shopify.discover', side_effect=tap_shopify.discover)
+@mock.patch("builtins.print")
+class TestTokenInDiscoverMode(unittest.TestCase):
+
+    @mock.patch('tap_shopify.initialize_shopify_client', side_effect=resource_not_found_raiser)
+    def test_resource_not_found(self, mocked_client, mocked_print, mocked_discover, mocked_args):
+        '''
+            Verify exception is raised for ResourceNotFound with proper error message and
+            test that discover mode is called 
+        '''
+        mocked_args.return_value = Args()
+        try:
+            tap_shopify.main()
+        except tap_shopify.ShopifyError as e:
+            self.assertEqual(str(e), 'ResourceNotFound\nEnsure shop is entered correctly')
+            self.assertEqual(mocked_discover.call_count, 1)
+            self.assertEqual(mocked_client.call_count, 1)
+            self.assertEqual(mocked_print.call_count, 0)
+
+    @mock.patch('tap_shopify.initialize_shopify_client', side_effect=unauthorized_access_raiser)
+    def test_unauthorized_access(self, mocked_client, mocked_print, mocked_discover, mocked_args):
+        '''
+            Verify exception is raised for UnauthorizedAccess with proper error message and
+            test that discover mode is called 
+        '''
+        mocked_args.return_value = Args()
+        try:
+            tap_shopify.main()
+        except tap_shopify.ShopifyError as e:
+            self.assertEqual(str(e), 'UnauthorizedAccess\nInvalid access token - Re-authorize the connection')
+            self.assertEqual(mocked_discover.call_count, 1)
+            self.assertEqual(mocked_client.call_count, 1)
+            self.assertEqual(mocked_print.call_count, 0)
+
+    @mock.patch('tap_shopify.initialize_shopify_client', side_effect=connection_error_raiser)
+    def test_connection_error(self, mocked_client, mocked_print, mocked_discover, mocked_args):
+        '''
+            Verify exception is raised for ConnectionError with proper error message and
+            test that discover mode is called 
+        '''
+        mocked_args.return_value = Args()
+        try:
+            tap_shopify.main()
+        except tap_shopify.ShopifyError as e:
+            self.assertEqual(str(e), 'ConnectionError\n')
+            self.assertEqual(mocked_discover.call_count, 1)
+            self.assertEqual(mocked_client.call_count, 1)
+            self.assertEqual(mocked_print.call_count, 0)
+
+    @mock.patch('tap_shopify.initialize_shopify_client')
+    def test_no_error(self, mocked_client, mocked_print, mocked_discover, mocked_args):
+        '''
+            Verify that if no error during discover then print should be called once for
+            writing catalog
+        '''
+        mocked_args.return_value = Args()
+        tap_shopify.main()
+        self.assertEqual(mocked_discover.call_count, 1)
+        self.assertEqual(mocked_client.call_count, 1)
+        self.assertEqual(mocked_print.call_count, 1)

--- a/tests/unittests/test_transaction_canonicalize.py
+++ b/tests/unittests/test_transaction_canonicalize.py
@@ -22,6 +22,12 @@ class TestTransactionCanonicalize(unittest.TestCase):
         canonicalize(record, "foo")
         self.assertEqual(record, expected_record)
 
+    def test_null_receipt_record(self):
+        record = {"receipt": None}
+        expected_record = {"receipt": None}
+        canonicalize(record, "foo")
+        self.assertEqual(record, expected_record)
+
     def test_removes_uppercase_if_both_exist_and_are_equal(self):
         record = {"receipt": {"Foo": "bar", "foo": "bar"}, "id": 2}
         expected_record = {"receipt": {"foo": "bar"}, "id": 2}


### PR DESCRIPTION
# Context
On 429s (rate limiting), the tapcode runs into an error in which it gives up upon 2 consecutive 429 responses from an endpoint, despite code logic defining behaviour in which the tapcode will never give up on 429s.

The root cause runs deep into package files and likely stems from a complex, low-level artefact of the language which would be non-trivial to debug and resolve.

The changes in this PR simply changes the handling of 429 responses to use the default, exponential backoff behaviour that it uses for other (eg 5xx code) failure response codes. These give up after 9 retries, which is sufficient to overcome any rate limiting encountered.

# Changes
- Add default wait time of 5 to backoff time parser (no longer used)
- Use exponential backoff for 429/rate limited responses

[Asana task](https://app.asana.com/0/1200015380021498/1201748096029958/f)
 
