### PR TITLE
Try to backoff when getting error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.5.1",
+    version="1.5.2",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",


### PR DESCRIPTION
Currently, the process is failing too easily instead of just retrying a bunch

- Move the status code circuit breakers (aka always retry duh)
- Create DEFAULT_WAIT time of 20 secs to be used if we can't parse the
  wait time from the response

# Description of change
(write a short description here or paste a link to JIRA)

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
