### PR TITLE
Add retry handling to smart & custom collections

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.5.2",
+    version="1.5.3",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/tap_shopify/streams/custom_collections_products.py
+++ b/tap_shopify/streams/custom_collections_products.py
@@ -13,12 +13,21 @@ class CustomCollectionsProducts(Stream):
     replication_key = 'updated_at'
 
     @shopify_error_handling
+    def get_collection_products(self, collection):
+        return collection.products()
+
+    @shopify_error_handling
+    def get_custom_collections_products(self):
+        # set timeout
+        self.replication_object.set_timeout(self.request_timeout)
+        return self.replication_object.find()
+
     def get_objects(self):
         'Paginate the return and add collection_id to returned product objects'
-        page = self.replication_object.find()
+        page = self.get_custom_collections_products()
         while True:
             for collection in page:
-                collection_products_page = collection.products()
+                collection_products_page = self.get_collection_products(collection)
                 while True:
                     for product in collection_products_page:
                         edit_product = product.to_dict()

--- a/tap_shopify/streams/smart_collections_products.py
+++ b/tap_shopify/streams/smart_collections_products.py
@@ -12,12 +12,21 @@ class SmartCollectionsProducts(Stream):
     replication_key = 'updated_at'
 
     @shopify_error_handling
+    def get_collection_products(self, collection):
+        return collection.products()
+
+    @shopify_error_handling
+    def get_smart_collections_products(self):
+        # set timeout
+        self.replication_object.set_timeout(self.request_timeout)
+        return self.replication_object.find()
+
     def get_objects(self):
         'Paginate the return and add collection_id to returned product objects'
-        page = self.replication_object.find()
+        page = self.get_smart_collections_products()
         while True:
             for collection in page:
-                collection_products_page = collection.products()
+                collection_products_page = self.get_collection_products(collection)
                 while True:
                     for product in collection_products_page:
                         edit_product = product.to_dict()


### PR DESCRIPTION
## Context
HTTP requests failing on `smart_collection_products` and `custom_collection_products` are currently not going through the error handling decorator and failing on first try.

## Changes
Extract the stream grabbing methods and wrap with a decorator

## Asana Task
[Task](https://app.asana.com/0/1200015380021498/1201790221236137/f)
[Test](https://github.com/lexerdev/integration-scripts/pull/529)