### PR TITLE
Add next page retry handling to collections

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.5.3",
+    version="1.5.4",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/tap_shopify/streams/collection_products.py
+++ b/tap_shopify/streams/collection_products.py
@@ -13,15 +13,28 @@ class CollectionProducts(Stream):
     replication_key = 'updated_at'
 
     @shopify_error_handling
+    def get_collection_products(self, collection):
+        return collection.products()
+
+    @shopify_error_handling
+    def get_collections_products(self):
+        # set timeout
+        self.replication_object.set_timeout(self.request_timeout)
+        return self.replication_object.find()
+
+    @shopify_error_handling
+    def get_next_page(self, page):
+        return page.next_page()
+
     def get_objects(self):
         
         while True:
-            page = self.replication_object.find()
+            page = self.get_collections_products()
             for collection in page:
-                for product in collection.products():
+                for product in self.get_collection_products(collection):
                     yield product
             if page.has_next_page():
-                page = page.next_page()
+                page = self.get_next_page(page)
             else:
                 break
 

--- a/tap_shopify/streams/custom_collections_products.py
+++ b/tap_shopify/streams/custom_collections_products.py
@@ -22,6 +22,10 @@ class CustomCollectionsProducts(Stream):
         self.replication_object.set_timeout(self.request_timeout)
         return self.replication_object.find()
 
+    @shopify_error_handling
+    def get_next_page(self, page):
+        return page.next_page()
+
     def get_objects(self):
         'Paginate the return and add collection_id to returned product objects'
         page = self.get_custom_collections_products()
@@ -34,11 +38,11 @@ class CustomCollectionsProducts(Stream):
                         edit_product["collection_id"] = collection.id
                         yield edit_product
                     if collection_products_page.has_next_page():
-                        collection_products_page = collection_products_page.next_page()
+                        collection_products_page = self.get_next_page(collection_products_page)
                     else:
                         break
             if page.has_next_page():
-                page = page.next_page()
+                page = self.get_next_page(page)
             else:
                 break
 

--- a/tap_shopify/streams/smart_collections_products.py
+++ b/tap_shopify/streams/smart_collections_products.py
@@ -21,6 +21,10 @@ class SmartCollectionsProducts(Stream):
         self.replication_object.set_timeout(self.request_timeout)
         return self.replication_object.find()
 
+    @shopify_error_handling
+    def get_next_page(self, page):
+        return page.next_page()
+
     def get_objects(self):
         'Paginate the return and add collection_id to returned product objects'
         page = self.get_smart_collections_products()
@@ -33,11 +37,11 @@ class SmartCollectionsProducts(Stream):
                         edit_product["collection_id"] = collection.id
                         yield edit_product
                     if collection_products_page.has_next_page():
-                        collection_products_page = collection_products_page.next_page()
+                        collection_products_page = self.get_next_page(collection_products_page)
                     else:
                         break
             if page.has_next_page():
-                page = page.next_page()
+                page = self.get_next_page(page)
             else:
                 break
 

--- a/tap_shopify/streams/transactions.py
+++ b/tap_shopify/streams/transactions.py
@@ -71,6 +71,10 @@ class Transactions(Stream):
             order_id=parent_object.id,
         )
 
+    @shopify_error_handling
+    def get_next_page(self, page):
+        return page.next_page()
+
     def get_transactions(self, parent_object):
         # We do not need to support paging on this substream. If that
         # were to become untrue, reference Metafields.
@@ -85,7 +89,7 @@ class Transactions(Stream):
         yield from page
 
         while page.has_next_page():
-            page = page.next_page()
+            page = self.get_next_page(page)
             yield from page
 
     def get_objects(self):


### PR DESCRIPTION
## Context
Next page requests on `collections` and `transaction` and currently not being retried on error.

## Changes
Add `@shopify_error_handling` retry decorator to the `next_page` and other stream requests.

## Task
https://app.asana.com/0/1200015380021498/1201790130152450/f