### PR TITLE
Shopify: update API to version 2022-07

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.5.4",
+    version="1.5.5",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",
@@ -11,7 +11,7 @@ setup(
     python_requires='>=3.5.2',
     py_modules=["tap_shopify"],
     install_requires=[
-        "ShopifyAPI==9.0.0",
+        "ShopifyAPI==12.0.1",
         "singer-python==5.12.1",
     ],
     extras_require={

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -25,7 +25,7 @@ SDC_KEYS = {'id': 'integer', 'name': 'string', 'myshopify_domain': 'string'}
 def initialize_shopify_client():
     api_key = Context.config['api_key']
     shop = Context.config['shop']
-    version = '2021-07'
+    version = '2022-07'
     session = shopify.Session(shop, version, api_key)
     shopify.ShopifyResource.activate_session(session)
 


### PR DESCRIPTION
## Context:
* update shopify python package so it has access to `2022-07` version of the shopify API
* increment version