### PR TITLE
Bump shopify API version to 2022-10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     python_requires='>=3.5.2',
     py_modules=["tap_shopify"],
     install_requires=[
-        "ShopifyAPI==12.0.1",
+        "ShopifyAPI==12.3.0",
         "singer-python==5.12.1",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.5.5",
+    version="1.5.6",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -25,7 +25,7 @@ SDC_KEYS = {'id': 'integer', 'name': 'string', 'myshopify_domain': 'string'}
 def initialize_shopify_client():
     api_key = Context.config['api_key']
     shop = Context.config['shop']
-    version = '2022-07'
+    version = '2022-10'
     session = shopify.Session(shop, version, api_key)
     shopify.ShopifyResource.activate_session(session)
 


### PR DESCRIPTION
## Context

This updates the Shopify API version to 2022-10, before the deprecation of 2022-07 next month

## Changes

- Bump the ShopifyAPI pypi installed version to 12.3.0
- Bump the API version to 2022-10
- Bump the pypi version of this package repo to 1.5.6
