### PR TITLE
consume all locations each pull

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.5.6",
+    version="1.5.7",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/tap_shopify/streams/locations.py
+++ b/tap_shopify/streams/locations.py
@@ -20,21 +20,7 @@ class Locations(Stream):
             yield from location_page
 
     def sync(self):
-        bookmark = self.get_bookmark()
-        max_bookmark = bookmark
-
         for location in self.get_locations_data():
-
-            location_dict = location.to_dict()
-            replication_value = utils.strptime_to_utc(location_dict[self.replication_key])
-
-            if replication_value >= bookmark:
-                yield location_dict
-
-            # update max bookmark if "replication_value" of current location is greater
-            if replication_value > max_bookmark:
-                max_bookmark = replication_value
-
-        self.update_bookmark(utils.strftime(max_bookmark))
+            yield location.to_dict()
 
 Context.stream_objects['locations'] = Locations


### PR DESCRIPTION
## Context:
* We need to get information about all physical stores, we can do this via the `Location` endpoint https://shopify.dev/docs/api/admin-rest/2022-10/resources/location#get-locations
* It returns a list of all locations a client has (stores)
* We can match this id up to the `location_id` field we get in the `order` file

## Changes:
* Turns out this was already implemented but it was filtering off the `updated_at` field, I've changed it to just pull all of them each time

## ASANA:
* https://app.asana.com/0/1200015380021498/1204896630437365/f
