### PR TITLE
upgrade api from 2023-10 -> 2024-01

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.6.1",
+    version="1.6.2",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -25,7 +25,7 @@ SDC_KEYS = {'id': 'integer', 'name': 'string', 'myshopify_domain': 'string'}
 def initialize_shopify_client():
     api_key = Context.config['api_key']
     shop = Context.config['shop']
-    version = '2023-10'
+    version = '2024-01'
     LOGGER.info(f'Initializing Shopify client for {version}')
     session = shopify.Session(shop, version, api_key)
     shopify.ShopifyResource.activate_session(session)


### PR DESCRIPTION
## Context:
* Shopify API 2023-10 is out of date, upgrading to 2024-01
* increase version in setup also
* matching `integrations` PR to use this upgrade https://github.com/lexerdev/integrations/pull/1000

## ASANA:
* https://app.asana.com/0/739189019699846/1208582665556856/f


## Test
- [x] https://buildkite.com/lexer/integrations-au/builds/243748
customer file chilling here `/home/joelh/customers_20241021T121139776027.ndjson.gz` with the new `email_marketing_consent` field